### PR TITLE
Add model selection and startup validation to Aider UI

### DIFF
--- a/NoLight.py
+++ b/NoLight.py
@@ -1,70 +1,70 @@
-import re
 import threading
 import subprocess
 import tkinter as tk
-from tkinter import ttk
-from tkinter import scrolledtext
+from tkinter import ttk, scrolledtext, filedialog
 import os
-import sys
+import configparser
 
-AIDER_WORKDIR = r"C:\Users\Ben\Desktop\unity\NoLight"
+from utils import sanitize, should_suppress, verify_unity_project, verify_api_key
 
-# Lines to quietly ignore from Aider when no TTY is attached
-NO_TTY_PATTERNS = [
-    r"^Can't initialize prompt toolkit: No Windows console found",
-    r"^Terminal does not support pretty output",
-]
+# Map human-friendly names to actual model identifiers
+MODEL_OPTIONS = {
+    "High": "gpt-5",
+    "Medium": "gpt-5-mini",
+    "Low": "gpt-5-nano",
+}
 
-NO_TTY_REGEXES = [re.compile(pat) for pat in NO_TTY_PATTERNS]
+# Read default model from config.ini
+config = configparser.ConfigParser()
+config.read("config.ini")
+DEFAULT_MODEL = config.get("aider", "default_model", fallback="gpt-5-mini")
+DEFAULT_CHOICE = next((k for k, v in MODEL_OPTIONS.items() if v == DEFAULT_MODEL), "Medium")
 
-def sanitize(text: str) -> str:
-    # Remove newlines & quotes, collapse whitespace
-    text = text.replace('\n', ' ').replace('\r', ' ')
-    text = text.replace('"', '').replace("'", "")
-    text = re.sub(r'\s+', ' ', text).strip()
-    return text
 
-def should_suppress(line: str) -> bool:
-    return any(rx.search(line) for rx in NO_TTY_REGEXES)
-
-def run_aider(msg: str,
-              output_widget: scrolledtext.ScrolledText,
-              send_btn: ttk.Button,
-              txt_input: tk.Text,
-              use_external_console: bool):
+def run_aider(
+    msg: str,
+    output_widget: scrolledtext.ScrolledText,
+    send_btn: ttk.Button,
+    txt_input: tk.Text,
+    use_external_console: bool,
+    project_dir: str,
+    model: str,
+):
+    """Spawn the aider CLI and stream output back into the UI."""
     try:
-        cmd_args = ["aider", "--model", "gpt-5", "--message", msg]
+        cmd_args = ["aider", "--model", model, "--message", msg]
 
         output_widget.configure(state="normal")
-        output_widget.insert(tk.END, f"\n> aider --model gpt-5 --message \"{msg}\"\n\n")
+        output_widget.insert(
+            tk.END,
+            f"\n> aider --model {model} --message \"{msg}\"\n\n",
+        )
         output_widget.see(tk.END)
         output_widget.configure(state="disabled")
 
         if use_external_console:
             # Launch in a separate console so Aider has a real TTY
-            # (no streamed output back to the app in this mode).
             subprocess.Popen(
                 ["cmd.exe", "/c"] + cmd_args,
-                cwd=AIDER_WORKDIR,
-                creationflags=subprocess.CREATE_NEW_CONSOLE
+                cwd=project_dir,
+                creationflags=subprocess.CREATE_NEW_CONSOLE,
             )
             output_widget.configure(state="normal")
             output_widget.insert(tk.END, "[opened in external console]\n")
-            output_widget.insert(tk.END, "-"*60 + "\n")
+            output_widget.insert(tk.END, "-" * 60 + "\n")
             output_widget.configure(state="disabled")
-
         else:
-            # Stream output back into the widget (no TTY; we filter noisy warnings)
+            # Stream output back into the widget (no TTY; filter noisy warnings)
             proc = subprocess.Popen(
                 cmd_args,
-                cwd=AIDER_WORKDIR,
+                cwd=project_dir,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
-                bufsize=1
+                bufsize=1,
             )
 
-            # Read line-by-line
+            # Read line-by-line so the UI stays responsive
             for line in proc.stdout:
                 if should_suppress(line):
                     continue
@@ -76,15 +76,14 @@ def run_aider(msg: str,
             proc.wait()
             output_widget.configure(state="normal")
             output_widget.insert(tk.END, f"\n[exit code: {proc.returncode}]\n")
-            output_widget.insert(tk.END, "-"*60 + "\n")
+            output_widget.insert(tk.END, "-" * 60 + "\n")
             output_widget.see(tk.END)
             output_widget.configure(state="disabled")
-
     except FileNotFoundError:
         output_widget.configure(state="normal")
         output_widget.insert(
             tk.END,
-            "\n[error] Could not find 'aider'. Make sure it's installed and on your PATH.\n"
+            "\n[error] Could not find 'aider'. Make sure it's installed and on your PATH.\n",
         )
         output_widget.configure(state="disabled")
     finally:
@@ -92,26 +91,40 @@ def run_aider(msg: str,
         txt_input.config(state="normal")
         txt_input.focus_set()
 
+
 def on_send(event=None):
     raw = txt_input.get("1.0", tk.END)
     if not raw.strip():
         return
+    if not project_dir_var.get():
+        output.configure(state="normal")
+        output.insert(tk.END, "[error] Select a Unity project first\n")
+        output.configure(state="disabled")
+        return
     msg = sanitize(raw)
 
-    # Lock while running
     send_btn.config(state="disabled")
     txt_input.config(state="disabled")
 
+    model = MODEL_OPTIONS[model_var.get()]
     t = threading.Thread(
         target=run_aider,
-        args=(msg, output, send_btn, txt_input, ext_console_var.get()),
-        daemon=True
+        args=(
+            msg,
+            output,
+            send_btn,
+            txt_input,
+            ext_console_var.get(),
+            project_dir_var.get(),
+            model,
+        ),
+        daemon=True,
     )
     t.start()
 
-    # Clear for next prompt
     txt_input.config(state="normal")
     txt_input.delete("1.0", tk.END)
+
 
 # ---- UI ----
 root = tk.Tk()
@@ -122,23 +135,60 @@ main.grid(row=0, column=0, sticky="nsew")
 root.rowconfigure(0, weight=1)
 root.columnconfigure(0, weight=1)
 
+# API key status label
+api_status_label = ttk.Label(main, text="API key: checking...", foreground="orange")
+api_status_label.grid(row=0, column=0, columnspan=2, sticky="w")
+
+# Project directory selector
+project_dir_var = tk.StringVar(value="")
+
+def choose_dir():
+    path = filedialog.askdirectory()
+    if path:
+        if verify_unity_project(path):
+            project_dir_var.set(path)
+            dir_status_label.config(text="✓", foreground="green")
+        else:
+            project_dir_var.set("")
+            dir_status_label.config(text="✗", foreground="red")
+
+dir_btn = ttk.Button(main, text="Select Unity Project", command=choose_dir)
+
+dir_btn.grid(row=1, column=0, sticky="w", pady=(4, 0))
+
+dir_status_label = ttk.Label(main, text="", width=2)
+dir_status_label.grid(row=1, column=1, sticky="w", pady=(4, 0))
+
+# Model selection dropdown
+model_var = tk.StringVar(value=DEFAULT_CHOICE)
+model_label = ttk.Label(main, text="Model:")
+model_label.grid(row=2, column=0, sticky="e", pady=(4, 0))
+model_combo = ttk.Combobox(
+    main,
+    textvariable=model_var,
+    values=list(MODEL_OPTIONS.keys()),
+    state="readonly",
+)
+model_combo.grid(row=2, column=1, sticky="w", pady=(4, 0))
+
 # Input label
 lbl = ttk.Label(main, text="Message to Aider:")
-lbl.grid(row=0, column=0, sticky="w")
+lbl.grid(row=3, column=0, sticky="w", pady=(4, 0))
 
 # Multiline input (Shift+Enter for newline; Enter to send)
 txt_input = scrolledtext.ScrolledText(main, width=100, height=6, wrap="word")
-txt_input.grid(row=1, column=0, columnspan=2, sticky="nsew", pady=(4, 8))
-main.rowconfigure(1, weight=0)
+txt_input.grid(row=4, column=0, columnspan=2, sticky="nsew", pady=(4, 8))
+main.rowconfigure(4, weight=0)
+
 
 def on_return(event):
-    # Enter to send; prevent newline
     on_send()
     return "break"
 
+
 def on_shift_return(event):
-    # Allow newline with Shift+Enter
     return
+
 
 txt_input.bind("<Return>", on_return)
 txt_input.bind("<Shift-Return>", on_shift_return)
@@ -146,15 +196,32 @@ txt_input.focus_set()
 
 # Options row
 ext_console_var = tk.BooleanVar(value=False)
-ext_chk = ttk.Checkbutton(main, text="Use external console (avoid TTY warnings)", variable=ext_console_var)
-ext_chk.grid(row=2, column=0, sticky="w", pady=(0, 6))
+ext_chk = ttk.Checkbutton(
+    main,
+    text="Use external console (avoid TTY warnings)",
+    variable=ext_console_var,
+)
+ext_chk.grid(row=5, column=0, sticky="w", pady=(0, 6))
 
 send_btn = ttk.Button(main, text="Send (Enter)", command=on_send)
-send_btn.grid(row=2, column=1, sticky="e", pady=(0, 6))
+send_btn.grid(row=5, column=1, sticky="e", pady=(0, 6))
 
 # Output area
-output = scrolledtext.ScrolledText(main, width=100, height=24, wrap="word", state="disabled")
-output.grid(row=3, column=0, columnspan=2, sticky="nsew")
-main.rowconfigure(3, weight=1)
+output = scrolledtext.ScrolledText(
+    main, width=100, height=24, wrap="word", state="disabled"
+)
+output.grid(row=6, column=0, columnspan=2, sticky="nsew")
+main.rowconfigure(6, weight=1)
 
+
+def check_api_key():
+    try:
+        verify_api_key(os.environ.get("AIDER_OPENAI_API_KEY"))
+        api_status_label.config(text="API key: ✓", foreground="green")
+    except Exception:
+        api_status_label.config(text="API key: ✗", foreground="red")
+        send_btn.config(state="disabled")
+
+
+root.after(0, check_api_key)
 root.mainloop()

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Aider Prompt UI
+
+A small Tkinter-based interface for sending prompts to the [`aider`](https://github.com/paul-gauthier/aider) CLI.
+
+## Features
+- Dropdown to select model quality: **High** (`gpt-5`), **Medium** (`gpt-5-mini`, default), or **Low** (`gpt-5-nano`).
+- Project directory chooser with basic Unity project verification.
+- Multiline text area for composing prompts.
+- Startup check that validates the `AIDER_OPENAI_API_KEY` via a test API call.

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,2 @@
+[aider]
+default_model = gpt-5-mini

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,40 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import utils
+
+def test_sanitize_removes_noise():
+    raw = 'Hello\n\'Quote\'  Test'
+    assert utils.sanitize(raw) == 'Hello Quote Test'
+
+def test_should_suppress_matches_known_warning():
+    line = "Can't initialize prompt toolkit: No Windows console found"
+    assert utils.should_suppress(line)
+
+def test_verify_unity_project(tmp_path: Path):
+    (tmp_path / 'Assets').mkdir()
+    project_settings = tmp_path / 'ProjectSettings'
+    project_settings.mkdir()
+    (project_settings / 'ProjectVersion.txt').write_text('dummy')
+    assert utils.verify_unity_project(tmp_path)
+    for child in project_settings.iterdir():
+        child.unlink()
+    project_settings.rmdir()
+    assert not utils.verify_unity_project(tmp_path)
+
+def test_verify_api_key(monkeypatch):
+    def fake_request(url, headers):
+        resp = types.SimpleNamespace()
+        resp.status_code = 200
+        return resp
+    assert utils.verify_api_key('key', request_fn=fake_request)
+    def bad_request(url, headers):
+        resp = types.SimpleNamespace()
+        resp.status_code = 401
+        return resp
+    with pytest.raises(ValueError):
+        utils.verify_api_key('key', request_fn=bad_request)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,50 @@
+import os
+import re
+from typing import Callable
+
+import requests
+
+# Patterns to filter noisy warnings when no TTY is attached
+NO_TTY_PATTERNS = [
+    r"^Can't initialize prompt toolkit: No Windows console found",
+    r"^Terminal does not support pretty output",
+]
+
+# Compile regexes once at module import for efficiency
+NO_TTY_REGEXES = [re.compile(pat) for pat in NO_TTY_PATTERNS]
+
+
+def sanitize(text: str) -> str:
+    """Remove newlines and quotes, and collapse whitespace to single spaces."""
+    text = text.replace("\n", " ").replace("\r", " ")
+    text = text.replace('"', '').replace("'", "")
+    # Collapse any run of whitespace into a single space and trim
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def should_suppress(line: str) -> bool:
+    """Return True if the line matches known warnings to suppress."""
+    return any(rx.search(line) for rx in NO_TTY_REGEXES)
+
+
+def verify_unity_project(path: os.PathLike) -> bool:
+    """Basic Unity project check: ensure Assets folder and ProjectSettings/ProjectVersion.txt exist."""
+    path = os.fspath(path)
+    assets = os.path.join(path, "Assets")
+    proj_version = os.path.join(path, "ProjectSettings", "ProjectVersion.txt")
+    return os.path.isdir(assets) and os.path.isfile(proj_version)
+
+
+def verify_api_key(api_key: str, request_fn: Callable = requests.get) -> bool:
+    """Call OpenAI API to ensure the provided key is valid. Raises ValueError on failure."""
+    if not api_key:
+        raise ValueError("API key not provided")
+
+    resp = request_fn(
+        "https://api.openai.com/v1/models",
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    if resp.status_code == 200:
+        return True
+    raise ValueError("API key validation failed")


### PR DESCRIPTION
## Summary
- Add dropdown for choosing GPT model quality and configurable default
- Allow selecting a Unity project directory with validation and status indicator
- Validate `AIDER_OPENAI_API_KEY` on startup and disable send if missing
- Add utility functions with unit tests and create config/README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c01df98bc8832d93f5c51269928ef4