### PR TITLE
Add commit detection with configurable timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - Project directory chooser with basic Unity project verification.
 - Multiline text area for composing prompts.
 - Startup check that validates the `AIDER_OPENAI_API_KEY` via a test API call.
+- Adjustable timeout (default 5 minutes) for detecting the commit ID produced by aider. The timeout is stored in `config.ini` and can be modified from the UI.
+- When a commit ID is detected in aider's output, the console is cleared and the commit hash is recorded in a history box so previous runs are easy to review.

--- a/config.ini
+++ b/config.ini
@@ -1,2 +1,5 @@
 [aider]
 default_model = gpt-5-mini
+
+[ui]
+timeout_minutes = 5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+# Ensure the project root is on the Python path so we can import utils
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import utils
 
@@ -38,3 +39,25 @@ def test_verify_api_key(monkeypatch):
         return resp
     with pytest.raises(ValueError):
         utils.verify_api_key('key', request_fn=bad_request)
+
+
+def test_extract_commit_id_found():
+    """A commit hash embedded in the text should be returned."""
+    text = "Some output\nCommitted abcdef1 add feature\n"
+    assert utils.extract_commit_id(text) == "abcdef1"
+
+
+def test_extract_commit_id_missing():
+    """If no commit hash is present, None should be returned."""
+    text = "Aider did nothing useful"
+    assert utils.extract_commit_id(text) is None
+
+
+def test_load_and_save_timeout(tmp_path: Path):
+    """Saving then loading should persist the timeout value."""
+    cfg = tmp_path / "config.ini"
+    # When file is missing, default should be 5
+    assert utils.load_timeout(cfg) == 5
+    # After saving a new value, it should round-trip
+    utils.save_timeout(10, cfg)
+    assert utils.load_timeout(cfg) == 10

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,7 @@
 import os
 import re
+import configparser  # Read/write simple configuration values
+from pathlib import Path  # Locate config file relative to this module
 from typing import Callable
 
 import requests
@@ -12,6 +14,12 @@ NO_TTY_PATTERNS = [
 
 # Compile regexes once at module import for efficiency
 NO_TTY_REGEXES = [re.compile(pat) for pat in NO_TTY_PATTERNS]
+
+# Path to the shared config file sitting next to this module
+CONFIG_PATH = Path(__file__).with_name("config.ini")
+
+# Regex used to detect commit hashes in aider output
+COMMIT_RE = re.compile(r"(?:Committed|commit) ([0-9a-f]{7,40})", re.IGNORECASE)
 
 
 def sanitize(text: str) -> str:
@@ -48,3 +56,29 @@ def verify_api_key(api_key: str, request_fn: Callable = requests.get) -> bool:
     if resp.status_code == 200:
         return True
     raise ValueError("API key validation failed")
+
+
+def load_timeout(config_path: Path = CONFIG_PATH) -> int:
+    """Return timeout (minutes) from config or default to 5.
+
+    The config file uses a [ui] section; if it or the key is missing,
+    a default of 5 minutes is returned.
+    """
+    config = configparser.ConfigParser()
+    if config_path.exists():
+        config.read(config_path)
+    return config.getint("ui", "timeout_minutes", fallback=5)
+
+
+def save_timeout(value: int, config_path: Path = CONFIG_PATH) -> None:
+    """Persist the timeout value back to the config file."""
+    config = configparser.ConfigParser()
+    config["ui"] = {"timeout_minutes": str(value)}
+    with open(config_path, "w") as fh:
+        config.write(fh)
+
+
+def extract_commit_id(text: str) -> str | None:
+    """Return the first commit hash found in the text or None."""
+    match = COMMIT_RE.search(text)
+    return match.group(1) if match else None


### PR DESCRIPTION
## Summary
- capture commit hashes from aider output and record them in a commit history panel
- persist configurable timeout for commit detection via config.ini and UI spinbox
- expand utils with helpers and corresponding unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c02010e3f0832d9674708dd9fbde98