### PR TITLE
Add settings dialog and project directory caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 ## Features
 - Dropdown to select model quality: **High** (`gpt-5`), **Medium** (`gpt-5-mini`, default), or **Low** (`gpt-5-nano`).
 - Project directory chooser with basic Unity project verification.
+- Remembers the last selected Unity project and shows the current path next to the chooser.
 - Multiline text area for composing prompts.
 - Startup check that validates the `AIDER_OPENAI_API_KEY` via a test API call.
-- Adjustable timeout (default 5 minutes) for detecting the commit ID produced by aider. The timeout is stored in `config.ini` and can be modified from the UI.
+- Timeout for detecting the commit ID is adjustable (default 5 minutes) via a gear-icon settings dialog.
 - When a commit ID is detected in aider's output, the console is cleared and the commit hash is recorded in a history box so previous runs are easy to review.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,3 +61,13 @@ def test_load_and_save_timeout(tmp_path: Path):
     # After saving a new value, it should round-trip
     utils.save_timeout(10, cfg)
     assert utils.load_timeout(cfg) == 10
+
+
+def test_load_and_save_project_dir(tmp_path: Path):
+    """The last selected project directory should persist between runs."""
+    cache = tmp_path / "proj.txt"
+    # Without a cache file we expect None
+    assert utils.load_project_dir(cache) is None
+    # After saving a path it should load back the same value
+    utils.save_project_dir("/path/to/project", cache)
+    assert utils.load_project_dir(cache) == "/path/to/project"

--- a/utils.py
+++ b/utils.py
@@ -18,6 +18,11 @@ NO_TTY_REGEXES = [re.compile(pat) for pat in NO_TTY_PATTERNS]
 # Path to the shared config file sitting next to this module
 CONFIG_PATH = Path(__file__).with_name("config.ini")
 
+# File where we remember the last Unity project directory selected by the user.
+# Keeping it separate from the main config avoids storing file paths in
+# config.ini as per project guidelines.
+PROJECT_CACHE_PATH = Path(__file__).with_name("last_project_dir.txt")
+
 # Regex used to detect commit hashes in aider output
 COMMIT_RE = re.compile(r"(?:Committed|commit) ([0-9a-f]{7,40})", re.IGNORECASE)
 
@@ -76,6 +81,21 @@ def save_timeout(value: int, config_path: Path = CONFIG_PATH) -> None:
     config["ui"] = {"timeout_minutes": str(value)}
     with open(config_path, "w") as fh:
         config.write(fh)
+
+
+def load_project_dir(cache_path: Path = PROJECT_CACHE_PATH) -> str | None:
+    """Return the cached Unity project path or None if it is missing or empty."""
+    if cache_path.exists():
+        text = cache_path.read_text().strip()
+        # An empty file means no cached path was saved.
+        return text or None
+    return None
+
+
+def save_project_dir(path: str, cache_path: Path = PROJECT_CACHE_PATH) -> None:
+    """Persist the selected Unity project path so it can be reloaded later."""
+    with open(cache_path, "w") as fh:
+        fh.write(path)
 
 
 def extract_commit_id(text: str) -> str | None:


### PR DESCRIPTION
## Summary
- cache last selected Unity project directory and show it next to the chooser
- add gear-icon settings dialog for timeout configuration
- improve model selector alignment and input prompt text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c023a8253c832db21e2b496b84e46d