### PR TITLE
Refactor for generic working dir and stronger API key validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 
 ## Features
 - Dropdown to select model quality: **High** (`gpt-5`), **Medium** (`gpt-5-mini`, default), or **Low** (`gpt-5-nano`).
-- Project directory chooser with basic Unity project verification.
-- Remembers the last selected Unity project and shows the current path next to the chooser.
+- Working directory chooser that shows the current path and remembers the last selection.
 - Multiline text area for composing prompts.
-- Startup check that validates the `AIDER_OPENAI_API_KEY` via a test API call.
-- Runs the aider CLI behind the scenes via a pseudo-terminal so no extra console window is needed.
+- Startup check that validates the `OPENAI_API_KEY` via a test API call.
 - Timeout for detecting the commit ID is adjustable (default 5 minutes) via a gear-icon settings dialog.
 - When a commit ID is detected in aider's output, the console is cleared and the commit hash is recorded in a history box so previous runs are easy to review.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
 import sys
 import types
 from pathlib import Path
-import os
 
 import pytest
 
@@ -9,37 +8,49 @@ import pytest
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import utils
 
+
 def test_sanitize_removes_noise():
-    raw = 'Hello\n\'Quote\'  Test'
-    assert utils.sanitize(raw) == 'Hello Quote Test'
+    """Quotes and newlines should be stripped out."""
+    raw = "Hello\n'Quote'  Test"
+    assert utils.sanitize(raw) == "Hello Quote Test"
+
 
 def test_should_suppress_matches_known_warning():
     line = "Can't initialize prompt toolkit: No Windows console found"
     assert utils.should_suppress(line)
 
-def test_verify_unity_project(tmp_path: Path):
-    (tmp_path / 'Assets').mkdir()
-    project_settings = tmp_path / 'ProjectSettings'
-    project_settings.mkdir()
-    (project_settings / 'ProjectVersion.txt').write_text('dummy')
-    assert utils.verify_unity_project(tmp_path)
-    for child in project_settings.iterdir():
-        child.unlink()
-    project_settings.rmdir()
-    assert not utils.verify_unity_project(tmp_path)
 
-def test_verify_api_key(monkeypatch):
+def test_verify_api_key_success():
+    """A 200 response should validate the key."""
+
     def fake_request(url, headers):
         resp = types.SimpleNamespace()
         resp.status_code = 200
         return resp
-    assert utils.verify_api_key('key', request_fn=fake_request)
+
+    assert utils.verify_api_key("key", request_fn=fake_request)
+
+
+def test_verify_api_key_failure():
+    """Non-200 responses should raise ValueError with details."""
+
     def bad_request(url, headers):
         resp = types.SimpleNamespace()
         resp.status_code = 401
+        resp.text = "unauthorized"
         return resp
+
+    with pytest.raises(ValueError) as exc:
+        utils.verify_api_key("key", request_fn=bad_request)
+    assert "401" in str(exc.value)
+    assert "unauthorized" in str(exc.value)
+
+
+def test_verify_api_key_missing():
+    """Empty keys should raise an explicit error."""
+
     with pytest.raises(ValueError):
-        utils.verify_api_key('key', request_fn=bad_request)
+        utils.verify_api_key("")
 
 
 def test_extract_commit_id_found():
@@ -64,28 +75,11 @@ def test_load_and_save_timeout(tmp_path: Path):
     assert utils.load_timeout(cfg) == 10
 
 
-def test_load_and_save_project_dir(tmp_path: Path):
-    """The last selected project directory should persist between runs."""
-    cache = tmp_path / "proj.txt"
+def test_load_and_save_working_dir(tmp_path: Path):
+    """The last selected working directory should persist between runs."""
+    cache = tmp_path / "dir.txt"
     # Without a cache file we expect None
-    assert utils.load_project_dir(cache) is None
+    assert utils.load_working_dir(cache) is None
     # After saving a path it should load back the same value
-    utils.save_project_dir("/path/to/project", cache)
-    assert utils.load_project_dir(cache) == "/path/to/project"
-
-
-@pytest.mark.skipif(os.name == "nt", reason="PTY not supported on Windows")
-def test_spawn_pty_process_captures_output():
-    """Running a simple command through the pseudo-terminal should yield its output."""
-    proc, fd = utils.spawn_pty_process(["python", "-c", "print('hi')"])
-    with fd:
-        output = ""
-        try:
-            # Read lines until the child process closes the pseudo-terminal
-            for line in fd:
-                output += line
-        except OSError:
-            # Some platforms raise EIO when the slave end is closed; that's fine
-            pass
-    proc.wait()
-    assert "hi" in output
+    utils.save_working_dir("/path/to/dir", cache)
+    assert utils.load_working_dir(cache) == "/path/to/dir"

--- a/utils.py
+++ b/utils.py
@@ -4,9 +4,6 @@ import configparser  # Read/write simple configuration values
 from pathlib import Path  # Locate config file relative to this module
 from typing import Callable, Optional
 
-import subprocess  # Launch external commands
-import pty  # Allocate a pseudo-terminal so aider believes it has a real TTY
-
 import requests
 
 # Patterns to filter noisy warnings when no TTY is attached
@@ -21,10 +18,10 @@ NO_TTY_REGEXES = [re.compile(pat) for pat in NO_TTY_PATTERNS]
 # Path to the shared config file sitting next to this module
 CONFIG_PATH = Path(__file__).with_name("config.ini")
 
-# File where we remember the last Unity project directory selected by the user.
+# File where we remember the last working directory selected by the user.
 # Keeping it separate from the main config avoids storing file paths in
 # config.ini as per project guidelines.
-PROJECT_CACHE_PATH = Path(__file__).with_name("last_project_dir.txt")
+WORKING_DIR_CACHE_PATH = Path(__file__).with_name("last_working_dir.txt")
 
 # Regex used to detect commit hashes in aider output
 COMMIT_RE = re.compile(r"(?:Committed|commit) ([0-9a-f]{7,40})", re.IGNORECASE)
@@ -44,16 +41,16 @@ def should_suppress(line: str) -> bool:
     return any(rx.search(line) for rx in NO_TTY_REGEXES)
 
 
-def verify_unity_project(path: os.PathLike) -> bool:
-    """Basic Unity project check: ensure Assets folder and ProjectSettings/ProjectVersion.txt exist."""
-    path = os.fspath(path)
-    assets = os.path.join(path, "Assets")
-    proj_version = os.path.join(path, "ProjectSettings", "ProjectVersion.txt")
-    return os.path.isdir(assets) and os.path.isfile(proj_version)
-
-
 def verify_api_key(api_key: str, request_fn: Callable = requests.get) -> bool:
-    """Call OpenAI API to ensure the provided key is valid. Raises ValueError on failure."""
+    """Call OpenAI API to ensure the provided key is valid.
+
+    Raises
+    ------
+    ValueError
+        If the key is missing or the API responds with an error. The error
+        message includes the status code and response text for easier
+        debugging.
+    """
     if not api_key:
         raise ValueError("API key not provided")
 
@@ -63,7 +60,10 @@ def verify_api_key(api_key: str, request_fn: Callable = requests.get) -> bool:
     )
     if resp.status_code == 200:
         return True
-    raise ValueError("API key validation failed")
+    # Surface details so the caller can display them to the user
+    raise ValueError(
+        f"API key validation failed: {resp.status_code} {getattr(resp, 'text', '')}"
+    )
 
 
 def load_timeout(config_path: Path = CONFIG_PATH) -> int:
@@ -86,8 +86,8 @@ def save_timeout(value: int, config_path: Path = CONFIG_PATH) -> None:
         config.write(fh)
 
 
-def load_project_dir(cache_path: Path = PROJECT_CACHE_PATH) -> Optional[str]:
-    """Return the cached Unity project path or None if it is missing or empty."""
+def load_working_dir(cache_path: Path = WORKING_DIR_CACHE_PATH) -> Optional[str]:
+    """Return the cached working directory or None if it is missing or empty."""
     if cache_path.exists():
         text = cache_path.read_text().strip()
         # An empty file means no cached path was saved.
@@ -95,8 +95,8 @@ def load_project_dir(cache_path: Path = PROJECT_CACHE_PATH) -> Optional[str]:
     return None
 
 
-def save_project_dir(path: str, cache_path: Path = PROJECT_CACHE_PATH) -> None:
-    """Persist the selected Unity project path so it can be reloaded later."""
+def save_working_dir(path: str, cache_path: Path = WORKING_DIR_CACHE_PATH) -> None:
+    """Persist the selected working directory so it can be reloaded later."""
     with open(cache_path, "w") as fh:
         fh.write(path)
 
@@ -105,45 +105,3 @@ def extract_commit_id(text: str) -> Optional[str]:
     """Return the first commit hash found in the text or None."""
     match = COMMIT_RE.search(text)
     return match.group(1) if match else None
-
-
-def spawn_pty_process(cmd: list[str], cwd: str | None = None):
-    """Start ``cmd`` attached to a pseudo-terminal and return (proc, fd).
-
-    The returned ``fd`` is a readable text-mode file object that streams the
-    subprocess's combined stdout/stderr.  A pseudo-terminal is used so the
-    child process thinks it is connected to a real console, preventing TTY
-    warnings from tools like ``aider``.
-
-    Parameters
-    ----------
-    cmd:
-        Command and arguments to execute.
-    cwd:
-        Optional working directory for the subprocess.
-
-    Raises
-    ------
-    RuntimeError
-        If the current platform does not support pseudo-terminals.
-    """
-    if os.name == "nt":
-        # Windows lacks native pty support; surface the limitation loudly so
-        # callers know they need another strategy.
-        raise RuntimeError("Pseudo-terminal support is required but unavailable on Windows")
-
-    # Create a master/slave pair. The slave end is handed to the subprocess and
-    # the master end is wrapped in a text-mode file object for the caller to read.
-    master_fd, slave_fd = pty.openpty()
-    proc = subprocess.Popen(
-        cmd,
-        cwd=cwd,
-        stdin=slave_fd,
-        stdout=slave_fd,
-        stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
-        close_fds=True,
-    )
-    os.close(slave_fd)
-    return proc, os.fdopen(master_fd)


### PR DESCRIPTION
## Summary
- Replace Unity-specific project selection with generic working directory support and optional external console mode
- Add OPENAI_API_KEY startup verification with helpful environment-variable link
- Expand utility tests for API key validation and working directory caching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0281f5f58832da0f7306c536cf445