### PR TITLE
Persist model setting and simplify UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - Startup check that validates the `OPENAI_API_KEY` via a test API call.
 - Timeout for detecting the commit ID is adjustable (default 5 minutes) via a gear-icon settings dialog.
 - When a commit ID is detected in aider's output, the console is cleared and the commit hash is recorded in a history box so previous runs are easy to review.
+- Model and timeout preferences are saved to a small config file so selections persist between sessions.
+
+## Author
+Ben Arnao

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -83,3 +83,17 @@ def test_load_and_save_working_dir(tmp_path: Path):
     # After saving a path it should load back the same value
     utils.save_working_dir("/path/to/dir", cache)
     assert utils.load_working_dir(cache) == "/path/to/dir"
+
+
+def test_load_and_save_default_model(tmp_path: Path):
+    """Changing the model should persist and coexist with other settings."""
+    cfg = tmp_path / "config.ini"
+    # Default fallback when config is absent
+    assert utils.load_default_model(cfg) == "gpt-5-mini"
+    # After saving, the chosen model should round-trip
+    utils.save_default_model("gpt-5", cfg)
+    assert utils.load_default_model(cfg) == "gpt-5"
+    # Saving the timeout afterwards should not erase the model choice
+    utils.save_timeout(7, cfg)
+    assert utils.load_default_model(cfg) == "gpt-5"
+    assert utils.load_timeout(cfg) == 7

--- a/utils.py
+++ b/utils.py
@@ -79,9 +79,40 @@ def load_timeout(config_path: Path = CONFIG_PATH) -> int:
 
 
 def save_timeout(value: int, config_path: Path = CONFIG_PATH) -> None:
-    """Persist the timeout value back to the config file."""
+    """Persist the timeout value back to the config file.
+
+    Any existing configuration values (e.g. the default model) are preserved so
+    that updates feel "real-time" and no settings are lost when another one is
+    changed.
+    """
     config = configparser.ConfigParser()
-    config["ui"] = {"timeout_minutes": str(value)}
+    if config_path.exists():
+        config.read(config_path)
+    # Ensure required sections exist before assigning values
+    if "ui" not in config:
+        config["ui"] = {}
+    config["ui"]["timeout_minutes"] = str(value)
+    with open(config_path, "w") as fh:
+        config.write(fh)
+
+
+def load_default_model(config_path: Path = CONFIG_PATH) -> str:
+    """Return the default model choice stored in config or a sensible fallback."""
+    config = configparser.ConfigParser()
+    if config_path.exists():
+        config.read(config_path)
+    return config.get("aider", "default_model", fallback="gpt-5-mini")
+
+
+def save_default_model(model: str, config_path: Path = CONFIG_PATH) -> None:
+    """Persist the selected model so it can be restored on next launch."""
+    config = configparser.ConfigParser()
+    if config_path.exists():
+        config.read(config_path)
+    if "aider" not in config:
+        config["aider"] = {}
+    config["aider"]["default_model"] = model
+    # Make sure we don't lose other sections such as [ui]
     with open(config_path, "w") as fh:
         config.write(fh)
 


### PR DESCRIPTION
## Summary
- persist model choice and timeout without losing other config values
- remove external console option and add `--yes-always` so aider runs internally without prompts
- streamline working directory display and tweak model dropdown spacing
- document author and session persistence in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c02bd20958832dbbcd0752b0cfee20