### PR TITLE
Add status bar and user prompt detection to Aider UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - Timeout for detecting the commit ID is adjustable (default 5 minutes) via a gear-icon settings dialog.
 - When a commit ID is detected in aider's output, the console is cleared and the commit hash is recorded in a history box so previous runs are easy to review.
 - Model and timeout preferences are saved to a small config file so selections persist between sessions.
+- A status bar keeps you informed whether the app is waiting on aider's response or for more input, and reports commit outcomes.
 
 ## Author
 Ben Arnao

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -65,6 +65,18 @@ def test_extract_commit_id_missing():
     assert utils.extract_commit_id(text) is None
 
 
+def test_needs_user_input_detects_prompt():
+    """Lines that start with 'Please' and end with '?' require user action."""
+    line = "Please add README.md to the chat so I can generate the exact SEARCH/REPLACE blocks?"
+    assert utils.needs_user_input(line)
+
+
+def test_needs_user_input_ignores_regular_output():
+    """Normal output lines should not be flagged as requiring input."""
+    line = "Aider v0.86.1"
+    assert not utils.needs_user_input(line)
+
+
 def test_load_and_save_timeout(tmp_path: Path):
     """Saving then loading should persist the timeout value."""
     cfg = tmp_path / "config.ini"


### PR DESCRIPTION
## Summary
- Show a status bar that reports when the app is waiting on aider, counts down to timeout, and confirms commit results.
- Detect aider prompts that require user input, update status accordingly, and prevent premature timeouts.
- Decode aider output as UTF-8 to avoid garbled characters and align the working directory path beside its button.
- Add unit tests for the new `needs_user_input` helper.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c02e4a5a5c832d8ca41d1fe6e986b7