### PR TITLE
Track requests with UUIDs and history table

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - Multiline text area for composing prompts.
 - Startup check that validates the `OPENAI_API_KEY` via a test API call.
 - Timeout for detecting the commit ID is adjustable (default 5 minutes) via a gear-icon settings dialog.
-- When a commit ID is detected in aider's output, the console is cleared and the commit hash is recorded in a history box so previous runs are easy to review.
+- Each request receives a unique identifier and is logged in a table that shows commit ids, line/file changes, and any failure reason.
 - Model and timeout preferences are saved to a small config file so selections persist between sessions.
-- A status bar keeps you informed whether the app is waiting on aider's response or for more input, and reports commit outcomes.
+- The Send button has been removed—press **Enter** to dispatch a prompt.
+- A status bar sits between the prompt area and the output, reporting whether we're waiting on aider or the user.
+- Output from previous requests remains visible so the full conversation can be reviewed.
 
 ## Author
 Ben Arnao


### PR DESCRIPTION
## Summary
- Assign each prompt a UUID and keep request history with commit stats
- Replace commit list with History button that opens a table of request details
- Remove Send button, rely on Enter, and keep output between requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0315c63fc832dada8b562c54310a8