### PR TITLE
Streamline model selection and history tracking

### DIFF
--- a/NoLight.py
+++ b/NoLight.py
@@ -16,8 +16,6 @@ from utils import (
     needs_user_input,
     load_working_dir,
     save_working_dir,
-    load_default_model,
-    save_default_model,
     get_commit_stats,  # Compute line/file counts for commits
 )
 
@@ -28,9 +26,8 @@ MODEL_OPTIONS = {
     "Low": "gpt-5-nano",
 }
 
-# Read default model from config.ini using helper that falls back gracefully
-DEFAULT_MODEL = load_default_model()
-DEFAULT_CHOICE = next((k for k, v in MODEL_OPTIONS.items() if v == DEFAULT_MODEL), "Medium")
+# Always start with the medium model; the choice isn't persisted between runs.
+DEFAULT_CHOICE = "Medium"
 
 # Track details for each user request so they can be shown in a history table.
 request_history: list[dict] = []  # List of per-request summaries
@@ -146,20 +143,19 @@ def run_aider(
             try:
                 # Query git for stats about the commit so we can store them.
                 stats = get_commit_stats(commit_id, work_dir)
+                # Store a simple summary of how many lines and files changed.
+                lines_total = stats["lines_changed"]
+                files_total = (
+                    stats["files_changed"]
+                    + stats["files_added"]
+                    + stats["files_removed"]
+                )
                 request_history.append(
                     {
                         "request_id": request_id,
                         "commit_id": commit_id,
-                        "lines": {
-                            "changed": stats["lines_changed"],
-                            "added": stats["lines_added"],
-                            "removed": stats["lines_removed"],
-                        },
-                        "files": {
-                            "changed": stats["files_changed"],
-                            "added": stats["files_added"],
-                            "removed": stats["files_removed"],
-                        },
+                        "lines": lines_total,
+                        "files": files_total,
                         "failure_reason": None,
                         "description": stats["description"],
                     }
@@ -173,8 +169,8 @@ def run_aider(
                     {
                         "request_id": request_id,
                         "commit_id": commit_id,
-                        "lines": {"changed": 0, "added": 0, "removed": 0},
-                        "files": {"changed": 0, "added": 0, "removed": 0},
+                        "lines": 0,
+                        "files": 0,
                         "failure_reason": f"stats error: {e}",
                         "description": "",
                     }
@@ -200,8 +196,8 @@ def run_aider(
                 {
                     "request_id": request_id,
                     "commit_id": None,
-                    "lines": {"changed": 0, "added": 0, "removed": 0},
-                    "files": {"changed": 0, "added": 0, "removed": 0},
+                    "lines": 0,
+                    "files": 0,
                     "failure_reason": failure_reason,
                     "description": "",
                 }
@@ -219,8 +215,8 @@ def run_aider(
             {
                 "request_id": request_id,
                 "commit_id": None,
-                "lines": {"changed": 0, "added": 0, "removed": 0},
-                "files": {"changed": 0, "added": 0, "removed": 0},
+                "lines": 0,
+                "files": 0,
                 "failure_reason": "aider not found",
                 "description": "",
             }
@@ -365,21 +361,13 @@ model_combo = ttk.Combobox(
 )
 model_combo.grid(row=2, column=3, sticky="w", pady=(4, 0))
 
-
-def on_model_change(*args):
-    """Persist model choice whenever the user selects a different option."""
-    save_default_model(MODEL_OPTIONS[model_var.get()])
-
-
-model_var.trace_add("write", on_model_change)
-
 # Input label
 lbl = ttk.Label(main, text="What can I do for you today?")
 lbl.grid(row=3, column=0, sticky="w", pady=(4, 0))
 
 # Multiline input (Shift+Enter for newline; Enter to send)
 txt_input = scrolledtext.ScrolledText(main, width=100, height=6, wrap="word")
-txt_input.grid(row=4, column=0, columnspan=4, sticky="nsew", pady=(4, 8))
+txt_input.grid(row=4, column=0, columnspan=4, sticky="nsew", pady=(4, 0))
 main.rowconfigure(4, weight=0)
 
 
@@ -398,14 +386,19 @@ txt_input.focus_set()
 
 # Status bar communicates whether we're waiting on aider or user input
 status_var = tk.StringVar(value="Aider is waiting on our input")
-status_label = ttk.Label(main, textvariable=status_var)
-status_label.grid(row=5, column=0, columnspan=4, sticky="w", pady=(0, 6))
+# Frame with a border so the status bar looks visually distinct and "boxed".
+status_frame = ttk.Frame(main, borderwidth=1, relief="solid")
+status_frame.grid(row=5, column=0, columnspan=4, sticky="ew", pady=0)
+status_label = ttk.Label(status_frame, textvariable=status_var)
+# Expand label to fill the frame horizontally.
+status_label.pack(fill="x", padx=2, pady=2)
 
 # Output area where aider output is streamed
 output = scrolledtext.ScrolledText(
     main, width=100, height=24, wrap="word", state="disabled"
 )
-output.grid(row=6, column=0, columnspan=4, sticky="nsew")
+# Attach the output area directly below the status frame with no spacing.
+output.grid(row=6, column=0, columnspan=4, sticky="nsew", pady=(0, 0))
 main.rowconfigure(6, weight=1)
 
 
@@ -413,15 +406,12 @@ def show_history():
     """Open a window displaying a table of previous requests."""
     win = tk.Toplevel(root)
     win.title("History")
+    # We only show total line and file counts for brevity.
     cols = (
         "request_id",
         "commit_id",
-        "lines_changed",
-        "lines_added",
-        "lines_removed",
-        "files_changed",
-        "files_added",
-        "files_removed",
+        "lines",
+        "files",
         "failure_reason",
         "description",
     )
@@ -435,12 +425,8 @@ def show_history():
             values=(
                 rec.get("request_id"),
                 rec.get("commit_id", ""),
-                rec["lines"]["changed"],
-                rec["lines"]["added"],
-                rec["lines"]["removed"],
-                rec["files"]["changed"],
-                rec["files"]["added"],
-                rec["files"]["removed"],
+                rec.get("lines", 0),
+                rec.get("files", 0),
                 rec.get("failure_reason", ""),
                 rec.get("description", ""),
             ),

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - Multiline text area for composing prompts.
 - Startup check that validates the `OPENAI_API_KEY` via a test API call.
 - Timeout for detecting the commit ID is adjustable (default 5 minutes) via a gear-icon settings dialog.
-- Each request receives a unique identifier and is logged in a table that shows commit ids, line/file changes, and any failure reason.
-- Model and timeout preferences are saved to a small config file so selections persist between sessions.
+- Each request receives a unique identifier and is logged in a table that shows commit ids, total line and file changes, and any failure reason.
+- Timeout preference is saved to a small config file, but the model always defaults to **Medium** on startup.
 - The Send button has been removed—press **Enter** to dispatch a prompt.
-- A status bar sits between the prompt area and the output, reporting whether we're waiting on aider or the user.
+- A boxed status bar sits between the prompt area and the output, reporting whether we're waiting on aider or the user.
 - Output from previous requests remains visible so the full conversation can be reviewed.
 
 ## Author

--- a/config.ini
+++ b/config.ini
@@ -1,5 +1,2 @@
-[aider]
-default_model = gpt-5-mini
-
 [ui]
 timeout_minutes = 5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,18 +98,16 @@ def test_load_and_save_working_dir(tmp_path: Path):
     assert utils.load_working_dir(cache) == "/path/to/dir"
 
 
-def test_load_and_save_default_model(tmp_path: Path):
-    """Changing the model should persist and coexist with other settings."""
+def test_model_selection_is_not_persisted(tmp_path: Path):
+    """Saving the model should have no effect on subsequent loads."""
     cfg = tmp_path / "config.ini"
-    # Default fallback when config is absent
+    # Loading should always return the medium model regardless of config file.
     assert utils.load_default_model(cfg) == "gpt-5-mini"
-    # After saving, the chosen model should round-trip
+    # Attempting to save a different model should not create or modify the file.
     utils.save_default_model("gpt-5", cfg)
-    assert utils.load_default_model(cfg) == "gpt-5"
-    # Saving the timeout afterwards should not erase the model choice
-    utils.save_timeout(7, cfg)
-    assert utils.load_default_model(cfg) == "gpt-5"
-    assert utils.load_timeout(cfg) == 7
+    assert utils.load_default_model(cfg) == "gpt-5-mini"
+    # Config file should not exist because nothing was persisted.
+    assert not cfg.exists()
 
 
 def test_get_commit_stats(tmp_path: Path):

--- a/utils.py
+++ b/utils.py
@@ -104,24 +104,26 @@ def save_timeout(value: int, config_path: Path = CONFIG_PATH) -> None:
 
 
 def load_default_model(config_path: Path = CONFIG_PATH) -> str:
-    """Return the default model choice stored in config or a sensible fallback."""
-    config = configparser.ConfigParser()
-    if config_path.exists():
-        config.read(config_path)
-    return config.get("aider", "default_model", fallback="gpt-5-mini")
+    """Return the model to use on startup.
+
+    Model selection is no longer persisted between sessions, so we always start
+    with the medium quality model (`gpt-5-mini`).
+    """
+
+    # Always use the medium model regardless of any existing config file.
+    return "gpt-5-mini"
 
 
 def save_default_model(model: str, config_path: Path = CONFIG_PATH) -> None:
-    """Persist the selected model so it can be restored on next launch."""
-    config = configparser.ConfigParser()
-    if config_path.exists():
-        config.read(config_path)
-    if "aider" not in config:
-        config["aider"] = {}
-    config["aider"]["default_model"] = model
-    # Make sure we don't lose other sections such as [ui]
-    with open(config_path, "w") as fh:
-        config.write(fh)
+    """Remember the selected model for the current run only.
+
+    The application intentionally forgets the model when it exits, so this
+    function is effectively a no-op. It exists to keep the call sites simple
+    and to make the intent explicit.
+    """
+
+    # Do nothing so no config file is written.
+    return None
 
 
 def load_working_dir(cache_path: Path = WORKING_DIR_CACHE_PATH) -> Optional[str]:


### PR DESCRIPTION
## Summary
- Default model now always starts at medium and isn't saved between sessions
- History table shows aggregated line and file counts for each request
- Status bar enclosed in a bordered box for clearer separation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c034702040832d90198fd7cf980e09