### PR TITLE
feat: add API usage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - The Send button has been removed—press **Enter** to dispatch a prompt.
 - A boxed status bar sits between the prompt area and the output, reporting whether we're waiting on aider or the user.
 - Output from previous requests remains visible so the full conversation can be reviewed.
+- An **API usage** button displays recent spending and remaining credits using the OpenAI billing API.
 
 ## Author
 Ben Arnao

--- a/config.ini
+++ b/config.ini
@@ -4,3 +4,7 @@ timeout_minutes = 1
 [aider]
 default_model = gpt-5-nano
 
+[usage]
+# Number of days of API usage history to query when showing billing info
+billing_days = 30
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -160,3 +160,50 @@ def test_get_commit_stats(tmp_path: Path):
     stats3 = utils.get_commit_stats(commit3, repo)
     assert stats3["files_removed"] == 1
     assert stats3["lines_removed"] == 2
+
+
+def test_load_usage_days(tmp_path: Path):
+    """Loading should return 30 by default and respect config value."""
+    cfg = tmp_path / "config.ini"
+    # Without a config file we expect the default window of 30 days.
+    assert utils.load_usage_days(cfg) == 30
+    # After writing a custom value it should be returned.
+    cfg.write_text("[usage]\nbilling_days = 10\n")
+    assert utils.load_usage_days(cfg) == 10
+
+
+def test_fetch_usage_data_parses_responses():
+    """Spending and credit info should be computed from API responses."""
+
+    def fake_request(url, headers=None, params=None):
+        resp = types.SimpleNamespace()
+        resp.status_code = 200
+        # Return usage cost in cents for the billing/usage endpoint.
+        if "billing/usage" in url:
+            resp.json = lambda: {"total_usage": 1234}
+        else:  # credit_grants endpoint
+            resp.json = lambda: {
+                "total_granted": 20,
+                "total_used": 5,
+                "total_available": 15,
+            }
+        return resp
+
+    stats = utils.fetch_usage_data("key", days=30, request_fn=fake_request)
+    assert stats["total_spent"] == pytest.approx(12.34)
+    assert stats["credits_total"] == 20
+    assert stats["credits_remaining"] == 15
+    assert stats["pct_credits_used"] == pytest.approx(25.0)
+
+
+def test_fetch_usage_data_error():
+    """Non-200 responses should raise ValueError."""
+
+    def bad_request(url, headers=None, params=None):
+        resp = types.SimpleNamespace()
+        resp.status_code = 500
+        resp.text = "boom"
+        return resp
+
+    with pytest.raises(ValueError):
+        utils.fetch_usage_data("key", request_fn=bad_request)


### PR DESCRIPTION
## Summary
- add utilities to fetch billing usage and credits
- expose API usage button in Tkinter UI
- document billing feature and cover with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c037a853c4832db10e5b3f2cc4ce95