### PR TITLE
Abbreviate history IDs and add table helpers

### DIFF
--- a/NoLight.py
+++ b/NoLight.py
@@ -20,6 +20,8 @@ from utils import (
     get_commit_stats,  # Compute line/file counts for commits
     load_usage_days,  # Read how far back to query billing data
     fetch_usage_data,  # Retrieve spending/credit information
+    format_history_row,  # Prepare rows for the history table
+    HISTORY_COL_WIDTHS,  # Default widths for history columns
 )
 
 # Map human-friendly names to actual model identifiers
@@ -421,19 +423,12 @@ def show_history():
     tree = ttk.Treeview(win, columns=cols, show="headings")
     for col in cols:
         tree.heading(col, text=col.replace("_", " ").title())
+        # Keep IDs and counts narrow but give text fields extra room.
+        anchor = "e" if col in {"lines", "files"} else "w"
+        tree.column(col, width=HISTORY_COL_WIDTHS[col], anchor=anchor)
     for rec in request_history:
-        tree.insert(
-            "",
-            tk.END,
-            values=(
-                rec.get("request_id"),
-                rec.get("commit_id", ""),
-                rec.get("lines", 0),
-                rec.get("files", 0),
-                rec.get("failure_reason", ""),
-                rec.get("description", ""),
-            ),
-        )
+        # Abbreviate IDs before inserting so the table stays compact.
+        tree.insert("", tk.END, values=format_history_row(rec))
     tree.pack(fill="both", expand=True)
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - Multiline text area for composing prompts.
 - Startup check that validates the `OPENAI_API_KEY` via a test API call.
 - Timeout for detecting the commit ID is adjustable (default 5 minutes) via a gear-icon settings dialog.
-- Each request receives a unique identifier and is logged in a table that shows commit ids, total line and file changes, and any failure reason.
+- Each request receives a unique identifier and is logged in a table that shows commit ids, total line and file changes, and any failure reason. The history view abbreviates IDs so the table remains compact.
 - Timeout preference is saved to a small config file, but the model always defaults to **Medium** on startup.
 - The Send button has been removed—press **Enter** to dispatch a prompt.
 - A boxed status bar sits between the prompt area and the output, reporting whether we're waiting on aider or the user.

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import utils
+
+
+def test_format_history_row_truncates_ids():
+    """IDs should be abbreviated to keep history rows compact."""
+    rec = {
+        "request_id": "1234567890abcdef",  # Longer than display length
+        "commit_id": "fedcba0987654321",  # Longer than display length
+        "lines": 12,
+        "files": 3,
+        "failure_reason": "oops",
+        "description": "something happened",
+    }
+    row = utils.format_history_row(rec)
+    # Only the first 8 characters should remain for the IDs
+    assert row[0] == "12345678"
+    assert row[1] == "fedcba09"
+    # The rest of the fields should pass through unchanged
+    assert row[2:] == (12, 3, "oops", "something happened")
+
+
+def test_history_column_width_defaults():
+    """History table should allocate more space for text fields."""
+    expected = {
+        "request_id": 80,
+        "commit_id": 80,
+        "lines": 60,
+        "files": 60,
+        "failure_reason": 200,
+        "description": 300,
+    }
+    assert utils.HISTORY_COL_WIDTHS == expected

--- a/utils.py
+++ b/utils.py
@@ -242,6 +242,45 @@ def get_commit_stats(commit_id: str, repo_path: str) -> dict:
     }
 
 
+# --- History helpers -------------------------------------------------------
+
+# Default column widths for the history table. ID and count columns stay
+# compact while textual fields get extra room for readability.
+HISTORY_COL_WIDTHS = {
+    "request_id": 80,
+    "commit_id": 80,
+    "lines": 60,
+    "files": 60,
+    "failure_reason": 200,
+    "description": 300,
+}
+
+
+def abbreviate(value: Optional[str], length: int = 8) -> str:
+    """Return the first ``length`` characters of ``value`` for compact display."""
+
+    if not value:
+        return ""
+    return value[:length]
+
+
+def format_history_row(rec: dict) -> tuple:
+    """Return display-friendly values for a history record.
+
+    The request/commit IDs are abbreviated so the history window can keep
+    narrow columns for those fields.
+    """
+
+    return (
+        abbreviate(rec.get("request_id")),
+        abbreviate(rec.get("commit_id")),
+        rec.get("lines", 0),
+        rec.get("files", 0),
+        rec.get("failure_reason", ""),
+        rec.get("description", ""),
+    )
+
+
 def load_usage_days(config_path: Path = CONFIG_PATH) -> int:
     """Return the number of days of usage data to request.
 


### PR DESCRIPTION
## Summary
- Compact history display with ID truncation and column width defaults
- Add utilities to format history rows
- Cover history helpers with unit tests and update README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c039a12b70832da1447f0749e2218e