### PR TITLE
Add resizable panes and color-coded status updates

### DIFF
--- a/NoLight.py
+++ b/NoLight.py
@@ -1,7 +1,7 @@
 import threading
 import subprocess
 import tkinter as tk
-from tkinter import ttk, scrolledtext, filedialog, messagebox
+from tkinter import ttk, filedialog, messagebox
 import os
 import time  # Track elapsed time when waiting for commit id
 import uuid  # Generate a unique id for each request
@@ -20,6 +20,7 @@ from utils import (
     get_commit_stats,  # Compute line/file counts for commits
     load_usage_days,  # Read how far back to query billing data
     fetch_usage_data,  # Retrieve spending/credit information
+    update_status,  # Helper to update status text and color
 )
 
 # Map human-friendly names to actual model identifiers
@@ -40,12 +41,13 @@ request_active = False  # True while we're waiting on aider to finish
 
 def run_aider(
     msg: str,
-    output_widget: scrolledtext.ScrolledText,
+    output_widget: tk.Text,
     txt_input: tk.Text,
     work_dir: str,
     model: str,
     timeout_minutes: int,
     status_var: tk.StringVar,
+    status_label: ttk.Label,
     request_id: str,
 ):
     """Spawn the aider CLI and capture commit details.
@@ -63,8 +65,11 @@ def run_aider(
 
         # Let the user know we're waiting on aider and start a simple countdown
         # so they can see when a timeout will occur.
-        status_var.set(
-            f"Waiting on aider's response... {timeout_minutes * 60} seconds to timeout"
+        update_status(
+            status_var,
+            status_label,
+            f"Waiting on aider's response... {timeout_minutes * 60} seconds to timeout",
+            "black",
         )
 
         output_widget.configure(state="normal")
@@ -99,8 +104,11 @@ def run_aider(
             # Stop updating once we have a result or are waiting on the user.
             if commit_id or failure_reason or waiting_on_user or remaining < 0:
                 return
-            status_var.set(
-                f"Waiting on aider's response... {remaining} seconds to timeout"
+            update_status(
+                status_var,
+                status_label,
+                f"Waiting on aider's response... {remaining} seconds to timeout",
+                "black",
             )
             root.after(1000, update_countdown)
 
@@ -125,7 +133,7 @@ def run_aider(
             # the user reply instead of timing out.
             if needs_user_input(line):
                 waiting_on_user = True
-                status_var.set("Aider is waiting on our input")
+                update_status(status_var, status_label, "Aider is waiting on our input", "orange")
                 proc.kill()
                 break
 
@@ -136,7 +144,12 @@ def run_aider(
                 and time.time() - start_time > timeout_minutes * 60
             ):
                 failure_reason = "Timed out waiting for commit id"
-                status_var.set("Failed to make commit due to timeout")
+                update_status(
+                    status_var,
+                    status_label,
+                    "Failed to make commit due to timeout",
+                    "red",
+                )
                 proc.kill()
                 break
 
@@ -163,8 +176,11 @@ def run_aider(
                         "description": stats["description"],
                     }
                 )
-                status_var.set(
-                    f"Successfully made changes with commit id {commit_id}"
+                update_status(
+                    status_var,
+                    status_label,
+                    f"Successfully made changes with commit id {commit_id}",
+                    "green",
                 )
             except Exception as e:
                 # If stats collection fails, record the error but keep running.
@@ -178,8 +194,11 @@ def run_aider(
                         "description": "",
                     }
                 )
-                status_var.set(
-                    f"Made commit {commit_id} but failed to gather stats"
+                update_status(
+                    status_var,
+                    status_label,
+                    f"Made commit {commit_id} but failed to gather stats",
+                    "red",
                 )
             request_active = False
         elif waiting_on_user:
@@ -194,7 +213,12 @@ def run_aider(
             output_widget.insert(tk.END, f"[exit code: {proc.returncode}]\n")
             output_widget.insert(tk.END, "-" * 60 + "\n")
             output_widget.configure(state="disabled")
-            status_var.set(f"Failed to make commit due to {failure_reason}")
+            update_status(
+                status_var,
+                status_label,
+                f"Failed to make commit due to {failure_reason}",
+                "red",
+            )
             request_history.append(
                 {
                     "request_id": request_id,
@@ -213,7 +237,12 @@ def run_aider(
             "\n[error] Could not find 'aider'. Make sure it's installed and on your PATH.\n",
         )
         output_widget.configure(state="disabled")
-        status_var.set("Failed to make commit due to missing 'aider'")
+        update_status(
+            status_var,
+            status_label,
+            "Failed to make commit due to missing 'aider'",
+            "red",
+        )
         request_history.append(
             {
                 "request_id": request_id,
@@ -262,6 +291,7 @@ def on_send(event=None):
             model,
             timeout_var.get(),  # Minutes to wait for commit id
             status_var,
+            status_label,  # Used to color-code status messages
             req_id,
         ),
         daemon=True,
@@ -368,10 +398,21 @@ model_combo.grid(row=2, column=3, sticky="w", pady=(4, 0))
 lbl = ttk.Label(main, text="What can I do for you today?")
 lbl.grid(row=3, column=0, sticky="w", pady=(4, 0))
 
-# Multiline input (Shift+Enter for newline; Enter to send)
-txt_input = scrolledtext.ScrolledText(main, width=100, height=6, wrap="word")
-txt_input.grid(row=4, column=0, columnspan=4, sticky="nsew", pady=(4, 0))
-main.rowconfigure(4, weight=0)
+# Paned window lets the user resize input vs. output areas
+paned = ttk.PanedWindow(main, orient="vertical")
+paned.grid(row=4, column=0, columnspan=4, sticky="nsew", pady=(4, 0))
+main.rowconfigure(4, weight=1)
+
+# --- Input area -----------------------------------------------------------
+input_frame = ttk.Frame(paned)
+txt_input = tk.Text(input_frame, wrap="word")  # User enters prompts here
+input_scroll = ttk.Scrollbar(input_frame, orient="vertical", command=txt_input.yview)
+txt_input.configure(yscrollcommand=input_scroll.set)
+txt_input.grid(row=0, column=0, sticky="nsew")
+input_scroll.grid(row=0, column=1, sticky="ns")
+input_frame.rowconfigure(0, weight=1)
+input_frame.columnconfigure(0, weight=1)
+paned.add(input_frame, weight=1)
 
 
 def on_return(event):
@@ -387,22 +428,24 @@ txt_input.bind("<Return>", on_return)
 txt_input.bind("<Shift-Return>", on_shift_return)
 txt_input.focus_set()
 
-# Status bar communicates whether we're waiting on aider or user input
+# --- Response area --------------------------------------------------------
+response_frame = ttk.Frame(paned)
+
 status_var = tk.StringVar(value="Aider is waiting on our input")
-# Frame with a border so the status bar looks visually distinct and "boxed".
-status_frame = ttk.Frame(main, borderwidth=1, relief="solid")
-status_frame.grid(row=5, column=0, columnspan=4, sticky="ew", pady=0)
+status_frame = ttk.Frame(response_frame, borderwidth=1, relief="solid")
+status_frame.grid(row=0, column=0, sticky="ew")
 status_label = ttk.Label(status_frame, textvariable=status_var)
-# Expand label to fill the frame horizontally.
 status_label.pack(fill="x", padx=2, pady=2)
 
-# Output area where aider output is streamed
-output = scrolledtext.ScrolledText(
-    main, width=100, height=24, wrap="word", state="disabled"
-)
-# Attach the output area directly below the status frame with no spacing.
-output.grid(row=6, column=0, columnspan=4, sticky="nsew", pady=(0, 0))
-main.rowconfigure(6, weight=1)
+output = tk.Text(response_frame, wrap="word", state="disabled")
+output_scroll = ttk.Scrollbar(response_frame, orient="vertical", command=output.yview)
+output.configure(yscrollcommand=output_scroll.set)
+output.grid(row=1, column=0, sticky="nsew")
+output_scroll.grid(row=1, column=1, sticky="ns")
+response_frame.rowconfigure(1, weight=1)
+response_frame.columnconfigure(0, weight=1)
+
+paned.add(response_frame, weight=3)
 
 
 def show_history():
@@ -471,11 +514,11 @@ def show_api_usage():
 
 # Simple button to pop up the history table
 history_btn = ttk.Button(main, text="History", command=show_history)
-history_btn.grid(row=7, column=0, sticky="w", pady=(6, 0))
+history_btn.grid(row=5, column=0, sticky="w", pady=(6, 0))
 
 # Button to display API usage information
 usage_btn = ttk.Button(main, text="API usage", command=show_api_usage)
-usage_btn.grid(row=7, column=3, sticky="e", pady=(6, 0))
+usage_btn.grid(row=5, column=3, sticky="e", pady=(6, 0))
 
 
 def open_env_settings(event=None):

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - Dropdown to select model quality: **High** (`gpt-5`), **Medium** (`gpt-5-mini`, default), or **Low** (`gpt-5-nano`).
 - Working directory chooser that shows the current path and remembers the last selection.
 - Multiline text area for composing prompts.
+- Draggable divider lets the prompt area take space from the response area when needed.
 - Startup check that validates the `OPENAI_API_KEY` via a test API call.
 - Timeout for detecting the commit ID is adjustable (default 5 minutes) via a gear-icon settings dialog.
 - Each request receives a unique identifier and is logged in a table that shows commit ids, total line and file changes, and any failure reason.
 - Timeout preference is saved to a small config file, but the model always defaults to **Medium** on startup.
 - The Send button has been removed—press **Enter** to dispatch a prompt.
 - A boxed status bar sits between the prompt area and the output, reporting whether we're waiting on aider or the user.
+- Successful commits highlight the status bar message in green.
 - Output from previous requests remains visible so the full conversation can be reviewed.
 - An **API usage** button displays recent spending and remaining credits using the OpenAI billing API.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -207,3 +207,29 @@ def test_fetch_usage_data_error():
 
     with pytest.raises(ValueError):
         utils.fetch_usage_data("key", request_fn=bad_request)
+
+
+def test_update_status_sets_message_and_color():
+    """update_status should set the text and color on the status label."""
+
+    class DummyVar:
+        def __init__(self):
+            self.value = ""
+
+        def set(self, value):
+            # Record the last message that was assigned.
+            self.value = value
+
+    class DummyLabel:
+        def __init__(self):
+            self.fg = ""
+
+        def config(self, **kwargs):
+            # Capture the foreground color the UI would display.
+            self.fg = kwargs.get("foreground", self.fg)
+
+    var = DummyVar()
+    lbl = DummyLabel()
+    utils.update_status(var, lbl, "hello", "green")
+    assert var.value == "hello"
+    assert lbl.fg == "green"

--- a/utils.py
+++ b/utils.py
@@ -160,6 +160,27 @@ def needs_user_input(line: str) -> bool:
     return any(rx.match(stripped) for rx in USER_INPUT_REGEXES)
 
 
+def update_status(status_var, status_label, message: str, color: str = "black") -> None:
+    """Update a Tk status label's text and color in one shot.
+
+    Parameters
+    ----------
+    status_var:
+        The ``StringVar`` associated with the label's text.
+    status_label:
+        The label widget whose foreground color should change.
+    message:
+        The text to display to the user describing the current state.
+    color:
+        The color name for the label's text (defaults to neutral black).
+    """
+
+    # Set the message so the user knows what's happening at a glance.
+    status_var.set(message)
+    # Color-code the message to quickly communicate success or failure.
+    status_label.config(foreground=color)
+
+
 def get_commit_stats(commit_id: str, repo_path: str) -> dict:
     """Return line and file change counts for a given commit.
 


### PR DESCRIPTION
## Summary
- add `update_status` helper to set status text and color
- color-code run status messages and make input/output panes resizable
- document resizable divider and green success status in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c039f3cc28832d82d7eb33dd893f49