### PR TITLE
Check build and run executables before launching Unity game

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - Timeout preference is saved to a small config file, but the model always defaults to **Medium** on startup.
 - The Send button has been removed—press **Enter** to dispatch a prompt.
 - A boxed status bar sits between the prompt area and the output, reporting whether we're waiting on aider or the user.
-- After a successful commit, the status bar offers a **Test changes** link that builds and launches your Unity project via the command line.
+- After a successful commit, the status bar offers a **Test changes** link that builds and launches your Unity project via the command line. Ensure the Unity CLI is installed and available on your `PATH` so the build step can run.
 - Output from previous requests remains visible so the full conversation can be reviewed.
 - An **API usage** button displays recent spending and remaining credits using the OpenAI billing API.
 


### PR DESCRIPTION
## Summary
- validate Unity build tool and game binary exist before launching
- document requirement for Unity CLI in PATH
- add unit tests covering success and failure cases for `build_and_launch_game`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c03b8d20a4832da0fb9265b61dbb64