### PR TITLE
Add status helper and resizable UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - Dropdown to select model quality: **High** (`gpt-5`), **Medium** (`gpt-5-mini`, default), or **Low** (`gpt-5-nano`).
 - Working directory chooser that shows the current path and remembers the last selection.
 - Multiline text area for composing prompts.
+- Draggable divider lets the prompt area take space from the response area when needed.
 - Startup check that validates the `OPENAI_API_KEY` via a test API call.
 - Timeout for detecting the commit ID is adjustable (default 5 minutes) via a gear-icon settings dialog.
 - Each request receives a unique identifier and is logged in a table that shows commit ids, total line and file changes, and any failure reason. The history view abbreviates IDs so the table remains compact.
 - Timeout preference is saved to a small config file, but the model always defaults to **Medium** on startup.
 - The Send button has been removed—press **Enter** to dispatch a prompt.
 - A boxed status bar sits between the prompt area and the output, reporting whether we're waiting on aider or the user.
-- After a successful commit, the status bar offers a **Test changes** link that builds and launches your Unity project via the command line.
+- Successful commits highlight the status bar message in green.
 - Output from previous requests remains visible so the full conversation can be reviewed.
 - An **API usage** button displays recent spending and remaining credits using the OpenAI billing API.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -208,6 +208,32 @@ def test_fetch_usage_data_error():
     with pytest.raises(ValueError):
         utils.fetch_usage_data("key", request_fn=bad_request)
 
+
+def test_update_status_sets_message_and_color():
+    """update_status should set both the text and the color."""
+
+    class DummyVar:
+        def __init__(self):
+            self.value = ""
+
+        def set(self, value):
+            # Store the last message assigned to the variable
+            self.value = value
+
+    class DummyLabel:
+        def __init__(self):
+            self.fg = ""
+
+        def config(self, **kwargs):
+            # Capture the requested foreground color
+            self.fg = kwargs.get("foreground", self.fg)
+
+    var = DummyVar()
+    lbl = DummyLabel()
+    utils.update_status(var, lbl, "hello", "green")
+    assert var.value == "hello"
+    assert lbl.fg == "green"
+
 def test_build_and_launch_game_runs(monkeypatch):
     """Building then launching should invoke subprocess.run and subprocess.Popen."""
     calls = []  # record the order and arguments of subprocess calls

--- a/utils.py
+++ b/utils.py
@@ -160,6 +160,27 @@ def needs_user_input(line: str) -> bool:
     return any(rx.match(stripped) for rx in USER_INPUT_REGEXES)
 
 
+def update_status(status_var, status_label, message: str, color: str = "black") -> None:
+    """Set a Tk status label's text and color in one call.
+
+    Parameters
+    ----------
+    status_var:
+        ``StringVar`` controlling the label's text.
+    status_label:
+        The label widget to recolor.
+    message:
+        Text shown to the user describing the current state.
+    color:
+        Foreground color name for the label (defaults to neutral black).
+    """
+
+    # Display the message so the user knows what is happening
+    status_var.set(message)
+    # Color-code the message to communicate success or failure at a glance
+    status_label.config(foreground=color)
+
+
 def get_commit_stats(commit_id: str, repo_path: str) -> dict:
     """Return line and file change counts for a given commit.
 


### PR DESCRIPTION
## Summary
- add reusable `update_status` helper to change status bar text and color
- switch GUI to paned window with resizable prompt/output areas
- color-code status messages (green for success, orange for input, red for failures)
- test `update_status` helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03c2bd994832db740a90041ad9cf5