### PR TITLE
Track request costs and remove billing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - A boxed status bar sits between the prompt area and the output, reporting whether we're waiting on aider or the user.
 - After a successful commit, the status bar offers a **Test changes** link that builds and launches your Unity project via the command line. Ensure the Unity CLI is installed and available on your `PATH` so the build step can run.
 - Output from previous requests remains visible so the full conversation can be reviewed.
-- An **API usage** button displays recent spending and remaining credits using the OpenAI billing API.
+- Each request's cost is tracked by parsing aider's output, with a running total shown in the UI.
 
 ## Author
 Ben Arnao

--- a/config.ini
+++ b/config.ini
@@ -4,7 +4,3 @@ timeout_minutes = 1
 [aider]
 default_model = gpt-5-nano
 
-[usage]
-# Number of days of API usage history to query when showing billing info
-billing_days = 30
-

--- a/nolight/app.py
+++ b/nolight/app.py
@@ -1,7 +1,7 @@
 import threading
 import subprocess
 import tkinter as tk
-from tkinter import ttk, scrolledtext, filedialog, messagebox
+from tkinter import ttk, scrolledtext, filedialog
 import os
 import uuid
 
@@ -12,8 +12,6 @@ from utils import (
     save_timeout,
     load_working_dir,
     save_working_dir,
-    load_usage_days,
-    fetch_usage_data,
     format_history_row,
     HISTORY_COL_WIDTHS,
 )
@@ -201,12 +199,13 @@ def main() -> None:
         """Open a window displaying a table of previous requests."""
         win = tk.Toplevel(root)
         win.title("History")
-        # We only show total line and file counts for brevity.
+        # We only show total line, file counts, and per-request cost for brevity.
         cols = (
             "request_id",
             "commit_id",
             "lines",
             "files",
+            "cost",
             "failure_reason",
             "description",
         )
@@ -214,50 +213,22 @@ def main() -> None:
         for col in cols:
             tree.heading(col, text=col.replace("_", " ").title())
             # Keep IDs and counts narrow but give text fields extra room.
-            anchor = "e" if col in {"lines", "files"} else "w"
+            anchor = "e" if col in {"lines", "files", "cost"} else "w"
             tree.column(col, width=HISTORY_COL_WIDTHS[col], anchor=anchor)
         for rec in runner.request_history:
             # Abbreviate IDs before inserting so the table stays compact.
             tree.insert("", tk.END, values=format_history_row(rec))
         tree.pack(fill="both", expand=True)
 
-    def show_api_usage() -> None:
-        """Open a window displaying recent API spending and credit details."""
-        api_key = os.environ.get("OPENAI_API_KEY")
-        if not api_key:
-            # Fail fast if the key is missing so the user knows why we cannot query.
-            messagebox.showerror("API Usage", "Env var OPENAI_API_KEY is not set")
-            return
-
-        # Read how far back to look for usage statistics from the config file.
-        days = load_usage_days()
-        try:
-            stats = fetch_usage_data(api_key, days=days)
-        except Exception as exc:
-            # Surface any API errors so the user can investigate.
-            messagebox.showerror("API Usage", str(exc))
-            return
-
-        # Average cost is approximated using the number of requests we have tracked.
-        avg_cost = stats["total_spent"] / len(runner.request_history) if runner.request_history else 0
-
-        win = tk.Toplevel(root)
-        win.title("API Usage")
-        msg = (
-            f"Amount spent (last {days} days): ${stats['total_spent']:.2f}\n"
-            f"Average cost per request: ${avg_cost:.2f}\n"
-            f"Credits remaining: ${stats['credits_remaining']:.2f} of ${stats['credits_total']:.2f}\n"
-            f"Percent credits used: {stats['pct_credits_used']:.2f}%"
-        )
-        ttk.Label(win, text=msg, justify="left").pack(padx=10, pady=10)
-
     # Simple button to pop up the history table
     history_btn = ttk.Button(main_frame, text="History", command=show_history)
     history_btn.grid(row=7, column=0, sticky="w", pady=(6, 0))
 
-    # Button to display API usage information
-    usage_btn = ttk.Button(main_frame, text="API usage", command=show_api_usage)
-    usage_btn.grid(row=7, column=3, sticky="e", pady=(6, 0))
+    # Display running total of money spent in the current session
+    session_cost_var = tk.StringVar(value="$0.00 spent this session")
+    runner.session_cost_var = session_cost_var
+    session_cost_label = ttk.Label(main_frame, textvariable=session_cost_var)
+    session_cost_label.grid(row=7, column=3, sticky="e", pady=(6, 0))
 
     def open_env_settings(event=None) -> None:
         """Open the system environment variable settings on Windows."""

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -14,6 +14,7 @@ def test_format_history_row_truncates_ids():
         "commit_id": "fedcba0987654321",  # Longer than display length
         "lines": 12,
         "files": 3,
+        "cost": 1.5,
         "failure_reason": "oops",
         "description": "something happened",
     }
@@ -22,7 +23,7 @@ def test_format_history_row_truncates_ids():
     assert row[0] == "12345678"
     assert row[1] == "fedcba09"
     # The rest of the fields should pass through unchanged
-    assert row[2:] == (12, 3, "oops", "something happened")
+    assert row[2:] == (12, 3, "$1.50", "oops", "something happened")
 
 
 def test_history_column_width_defaults():
@@ -32,6 +33,7 @@ def test_history_column_width_defaults():
         "commit_id": 80,
         "lines": 60,
         "files": 60,
+        "cost": 80,
         "failure_reason": 200,
         "description": 300,
     }


### PR DESCRIPTION
## Summary
- parse cost from aider output and accumulate session spending
- show per-request cost in history table and session total in main UI
- drop OpenAI billing API code and config entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c03eb60d10832d84baa8a2a0cc8dd7