### PR TITLE
Revamp UI with resizable panels and API usage metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - Timeout preference is saved to a small config file, but the model always defaults to **Medium** on startup.
 - The Send button has been removed—press **Enter** to dispatch a prompt.
 - A boxed status bar sits between the prompt area and the output, reporting whether we're waiting on aider or the user.
-- After a successful commit, the status bar offers a **Test changes** link that builds and launches your Unity project via the command line. Ensure the Unity CLI is installed and available on your `PATH` so the build step can run.
+- Draggable divider lets the prompt area take space from the response area when needed.
+- Successful commits highlight the status bar message in green.
 - Output from previous requests remains visible so the full conversation can be reviewed.
-- Each request's cost is tracked by parsing aider's output, with a running total shown in the UI.
+- An **API usage** button displays recent spending and remaining credits using the OpenAI billing API.
 
 ## Development Best Practices
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -14,7 +14,6 @@ def test_format_history_row_truncates_ids():
         "commit_id": "fedcba0987654321",  # Longer than display length
         "lines": 12,
         "files": 3,
-        "cost": 1.5,
         "failure_reason": "oops",
         "description": "something happened",
     }
@@ -23,7 +22,7 @@ def test_format_history_row_truncates_ids():
     assert row[0] == "12345678"
     assert row[1] == "fedcba09"
     # The rest of the fields should pass through unchanged
-    assert row[2:] == (12, 3, "$1.50", "oops", "something happened")
+    assert row[2:] == (12, 3, "oops", "something happened")
 
 
 def test_history_column_width_defaults():
@@ -33,7 +32,6 @@ def test_history_column_width_defaults():
         "commit_id": 80,
         "lines": 60,
         "files": 60,
-        "cost": 80,
         "failure_reason": 200,
         "description": 300,
     }


### PR DESCRIPTION
## Summary
- Add draggable splitter between prompt and response with status bar highlight
- Expose API usage stats via new OpenAI billing helper
- Centralize status updates and expand test coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c04098f4d8832d8c0e94e3498b9326