### PR TITLE
Clear previous output on new requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - After a successful commit, the status bar offers a **Test changes** link that builds and launches your Unity project via the command line. Configure the Unity Editor path via `config.ini` (`[build] build_cmd`), the `UNITY_PATH` environment variable, or let the app auto-detect a Unity Hub installation.
 - Draggable divider lets the prompt area take space from the response area when needed.
 - Successful commits highlight the status bar message in green.
-- Output from previous requests remains visible so the full conversation can be reviewed.
+- After a successful commit, starting a new request clears prior output so separate conversations don't mix.
 - An **API usage** button displays recent spending and remaining credits using the OpenAI billing API.
 
 ## Development Best Practices

--- a/nolight/app.py
+++ b/nolight/app.py
@@ -154,6 +154,8 @@ def main() -> None:
             output.configure(state="disabled")
             return
         msg = sanitize(raw)
+        # Remove old output if the last request finished with a commit.
+        runner.maybe_clear_output(output)
         # Disable input until aider responds so duplicate requests can't be sent.
         txt_input.config(state="disabled")
         # Generate a new request id only if we're starting a fresh request.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -35,3 +35,39 @@ def test_record_request_failure():
     assert rec["lines"] == 0
     assert rec["files"] == 0
     assert rec["failure_reason"] == "timeout"
+
+
+class DummyWidget:
+    """Minimal stand-in for a Tk text widget used in tests."""
+
+    def __init__(self):
+        self.content = "hello"
+        self.state = "normal"
+
+    def configure(self, state: str) -> None:
+        # Store the state but ignore it otherwise.
+        self.state = state
+
+    def delete(self, start: str, end: str) -> None:
+        # Simulate clearing all text from the widget.
+        self.content = ""
+
+
+def test_maybe_clear_output_resets_when_flag_set():
+    """Output should be cleared and flag reset when marked for reset."""
+    widget = DummyWidget()
+    runner.reset_on_new_request = True
+    runner.request_active = False
+    runner.maybe_clear_output(widget)
+    assert widget.content == ""
+    assert runner.reset_on_new_request is False
+
+
+def test_maybe_clear_output_no_reset_when_flag_unset():
+    """Widget remains unchanged if reset flag is not set."""
+    widget = DummyWidget()
+    widget.content = "stay"
+    runner.reset_on_new_request = False
+    runner.request_active = False
+    runner.maybe_clear_output(widget)
+    assert widget.content == "stay"


### PR DESCRIPTION
## Summary
- add reset flag so next request clears output after a successful commit
- expose `maybe_clear_output` helper and call it from the UI
- document new behavior and cover it with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0430a4554832db98323984ae3174e