### PR TITLE
Capture aider exit details when no commit ID is produced

### DIFF
--- a/nolight/runner.py
+++ b/nolight/runner.py
@@ -128,6 +128,7 @@ def run_aider(
         commit_id: Optional[str] = None
         failure_reason: Optional[str] = None
         waiting_on_user = False  # Set when aider asks for more information
+        last_line = ""  # Remember the most recent non-empty line from aider
 
         def update_countdown() -> None:
             """Refresh the status bar every second with remaining time."""
@@ -157,6 +158,11 @@ def run_aider(
             output_widget.see(tk.END)
             output_widget.configure(state="disabled")
 
+            # Keep track of the latest meaningful line for error reporting
+            stripped = line.strip()
+            if stripped:
+                last_line = stripped
+
             # Try to extract a commit hash from the stream.
             cid = extract_commit_id(line)
             if cid:
@@ -176,13 +182,8 @@ def run_aider(
                 and not waiting_on_user
                 and time.time() - start_time > timeout_minutes * 60
             ):
+                # Note the timeout but let final handling display and record it
                 failure_reason = "Timed out waiting for commit id"
-                update_status(
-                    status_var,
-                    status_label,
-                    "Failed to make commit due to timeout",
-                    "red",
-                )
                 proc.kill()
                 break
 
@@ -219,7 +220,9 @@ def run_aider(
             pass
         else:
             if failure_reason is None:
-                failure_reason = "No commit id found"
+                # Include exit code and last line so the user knows what happened
+                code = proc.returncode
+                failure_reason = f"aider exited with code {code}: {last_line}"
             output_widget.configure(state="normal")
             output_widget.insert(tk.END, f"\n[error] {failure_reason}\n")
             output_widget.insert(tk.END, f"[exit code: {proc.returncode}]\n")
@@ -231,6 +234,7 @@ def run_aider(
                 f"Failed to make commit due to {failure_reason}",
                 "red",
             )
+            # Store the detailed reason so it appears in the history table
             record_request(request_id, None, failure_reason=failure_reason)
             request_active = False
     except FileNotFoundError:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import io
 
 # Ensure project root is on path so we can import the package
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -35,3 +36,80 @@ def test_record_request_failure():
     assert rec["lines"] == 0
     assert rec["files"] == 0
     assert rec["failure_reason"] == "timeout"
+
+
+def test_run_aider_records_exit_reason(monkeypatch):
+    """run_aider should store exit code and last line on failure."""
+    runner.request_history.clear()
+
+    # Simple stand-ins for the Tk widgets so run_aider can interact with them
+    class DummyText:
+        def __init__(self):
+            self.text = ""
+
+        def insert(self, _idx, txt):
+            self.text += txt
+
+        def see(self, _idx):
+            pass
+
+        def configure(self, **kwargs):
+            pass
+
+        def config(self, **kwargs):
+            pass
+
+        def focus_set(self):
+            pass
+
+    class DummyVar:
+        def set(self, _val):
+            pass
+
+    class DummyLabel:
+        def config(self, **kwargs):
+            pass
+
+        def unbind(self, *_args, **_kwargs):
+            pass
+
+    class DummyRoot:
+        def after(self, *_args, **_kwargs):
+            pass
+
+    # Mock Popen to simulate aider exiting with an error
+    class MockPopen:
+        def __init__(self, *args, **kwargs):
+            # Provide two lines of output, the last being an error
+            self.stdout = io.StringIO("ok\nboom\n")
+            self.returncode = 2
+
+        def wait(self):
+            return self.returncode
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *a, **k: MockPopen())
+
+    output = DummyText()
+    txt_input = DummyText()
+    status_var = DummyVar()
+    status_label = DummyLabel()
+    root = DummyRoot()
+
+    runner.run_aider(
+        msg="hi",
+        output_widget=output,
+        txt_input=txt_input,
+        work_dir=".",
+        model="gpt-5",
+        timeout_minutes=1,
+        status_var=status_var,
+        status_label=status_label,
+        request_id="req1",
+        root=root,
+    )
+
+    rec = runner.request_history[0]
+    assert rec["failure_reason"] == "aider exited with code 2: boom"


### PR DESCRIPTION
## Summary
- track the last non-empty aider output line and use it with the exit code to build a detailed failure reason
- record and display this reason so failed requests show why aider exited
- add regression test to ensure failure reasons include exit code and final line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c045142b48832dbc21a79b8b2224a3