### PR TITLE
Remove timeout logic and track aider state via output

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - Working directory chooser that shows the current path and remembers the last selection.
 - Multiline text area for composing prompts.
 - Startup check that validates the `OPENAI_API_KEY` via a test API call.
-- Timeout for detecting the commit ID is adjustable (default 5 minutes) via a gear-icon settings dialog.
 - Each request receives a unique identifier and is logged in a table that shows commit ids, total line and file changes, and any failure reason. The history view abbreviates IDs so the table remains compact.
-- Timeout preference is saved to a small config file, but the model always defaults to **Medium** on startup.
 - The Send button has been removed—press **Enter** to dispatch a prompt.
 - A boxed status bar sits between the prompt area and the output, reporting whether we're waiting on aider or the user.
 - After a successful commit, the status bar offers a **Test changes** link that builds and launches your Unity project via the command line. Configure the Unity Editor path via `config.ini` (`[build] build_cmd`), the `UNITY_PATH` environment variable, or let the app auto-detect a Unity Hub installation.

--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,3 @@
-[ui]
-timeout_minutes = 1
-
 [aider]
 default_model = gpt-5-nano
 

--- a/nolight/app.py
+++ b/nolight/app.py
@@ -8,8 +8,6 @@ import uuid
 from utils import (
     sanitize,
     verify_api_key,
-    load_timeout,
-    save_timeout,
     load_working_dir,
     save_working_dir,
     load_usage_days,
@@ -42,39 +40,13 @@ def main() -> None:
     root.rowconfigure(0, weight=1)
     root.columnconfigure(0, weight=1)
 
-    # Default timeout pulled from config file and saved back when modified
-    timeout_var = tk.IntVar(value=load_timeout())
-
-    def on_timeout_change(*_args):
-        # Persist any changes to the timeout so it survives restarts
-        save_timeout(timeout_var.get())
-
-    timeout_var.trace_add("write", on_timeout_change)
-
     # Make the second column expandable so labels sit directly next to buttons
     for col in range(4):
         main_frame.columnconfigure(col, weight=1 if col == 1 else 0)
 
-    # API key status label
+    # API key status label spans the full row now that we have no settings button
     api_status_label = ttk.Label(main_frame, text="API key: checking...", foreground="orange")
-    # Span first three columns so a settings button can live in the fourth
-    api_status_label.grid(row=0, column=0, columnspan=3, sticky="w")
-
-    def open_settings() -> None:
-        """Pop up a small window to house UI-related settings."""
-        win = tk.Toplevel(root)
-        win.title("Settings")
-
-        ttk.Label(win, text="Timeout (min):").grid(row=0, column=0, padx=8, pady=8, sticky="w")
-        # The spinbox shares the same variable used in the main UI so changes
-        # automatically persist via the trace handler.
-        ttk.Spinbox(win, from_=1, to=60, textvariable=timeout_var, width=5).grid(
-            row=0, column=1, padx=8, pady=8, sticky="w"
-        )
-
-    # Simple gear icon button that opens the settings window
-    settings_btn = ttk.Button(main_frame, text="⚙", width=3, command=open_settings)
-    settings_btn.grid(row=0, column=3, sticky="e")
+    api_status_label.grid(row=0, column=0, columnspan=4, sticky="w")
 
     # Project directory selector
     work_dir_var = tk.StringVar(value="")
@@ -171,11 +143,9 @@ def main() -> None:
                 txt_input,
                 work_dir_var.get(),
                 model,
-                timeout_var.get(),  # Minutes to wait for commit id
                 status_var,
                 status_label,
                 req_id,
-                root,
             ),
             daemon=True,
         )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,5 +1,8 @@
 import sys
 from pathlib import Path
+import types
+
+import pytest
 
 # Ensure project root is on path so we can import the package
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -29,9 +32,151 @@ def test_record_request_success():
 def test_record_request_failure():
     """Failures should record the reason and zero counts."""
     runner.request_history.clear()
-    runner.record_request("id2", None, failure_reason="timeout")
+    runner.record_request("id2", None, failure_reason="error")
     rec = runner.request_history[0]
     assert rec["commit_id"] is None
     assert rec["lines"] == 0
     assert rec["files"] == 0
-    assert rec["failure_reason"] == "timeout"
+    assert rec["failure_reason"] == "error"
+
+
+def test_run_aider_records_commit(monkeypatch, tmp_path):
+    """A commit hash in aider's output should record the request and end the run."""
+
+    class DummyText:
+        """Simplified stand-in for Tk's Text widget."""
+
+        def __init__(self):
+            self.state = "normal"
+
+        def configure(self, **_):
+            pass
+
+        def insert(self, _idx, _text):
+            pass
+
+        def see(self, _idx):
+            pass
+
+        def config(self, **kwargs):  # for txt_input
+            self.state = kwargs.get("state", self.state)
+
+        def focus_set(self):
+            pass
+
+    class DummyVar:
+        def __init__(self):
+            self.value = ""
+
+        def set(self, value):
+            self.value = value
+
+    class DummyLabel:
+        def config(self, **_):
+            pass
+
+        def unbind(self, _):
+            pass
+
+    # Simulate aider emitting a commit line
+    lines = iter(["Committed abcdef1 add feature\n"])
+
+    class FakeProc:
+        def __init__(self):
+            self.stdout = lines
+            self.returncode = 0
+
+        def kill(self):
+            pass
+
+        def wait(self):
+            pass
+
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *a, **k: FakeProc())
+    monkeypatch.setattr(
+        runner,
+        "get_commit_stats",
+        lambda cid, wd: {"lines_changed": 1, "files_changed": 0, "files_added": 0, "files_removed": 0, "description": "msg"},
+    )
+
+    out = DummyText()
+    inp = DummyText()
+    var = DummyVar()
+    lbl = DummyLabel()
+
+    runner.request_history.clear()
+    runner.request_active = True
+    runner.run_aider("msg", out, inp, str(tmp_path), "model", var, lbl, "req1")
+
+    assert runner.request_history[0]["commit_id"] == "abcdef1"
+    assert not runner.request_active  # run ended after commit
+    assert "Successfully" in var.value
+
+
+def test_run_aider_waits_on_user(monkeypatch, tmp_path):
+    """When aider requests input, the run should stop without recording a commit."""
+
+    class DummyText:
+        def __init__(self):
+            self.state = "normal"
+
+        def configure(self, **_):
+            pass
+
+        def insert(self, _idx, _text):
+            pass
+
+        def see(self, _idx):
+            pass
+
+        def config(self, **kwargs):
+            self.state = kwargs.get("state", self.state)
+
+        def focus_set(self):
+            pass
+
+    class DummyVar:
+        def __init__(self):
+            self.value = ""
+
+        def set(self, value):
+            self.value = value
+
+    class DummyLabel:
+        def config(self, **_):
+            pass
+
+        def unbind(self, _):
+            pass
+
+    # Line mimics aider asking for more details
+    lines = iter(["Please add README.md to the chat so I can generate the exact SEARCH/REPLACE blocks?\n"])
+
+    class FakeProc:
+        def __init__(self):
+            self.stdout = lines
+            self.returncode = 0
+            self.killed = False
+
+        def kill(self):
+            self.killed = True
+
+        def wait(self):
+            pass
+
+    fake = FakeProc()
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *a, **k: fake)
+
+    out = DummyText()
+    inp = DummyText()
+    var = DummyVar()
+    lbl = DummyLabel()
+
+    runner.request_history.clear()
+    runner.request_active = True
+    runner.run_aider("msg", out, inp, str(tmp_path), "model", var, lbl, "req2")
+
+    assert runner.request_history == []  # no commit recorded
+    assert runner.request_active  # still waiting for follow-up input
+    assert "waiting" in var.value.lower()
+    assert fake.killed  # process should be terminated

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,16 +90,6 @@ def test_needs_user_input_ignores_regular_output():
     assert not utils.needs_user_input(line)
 
 
-def test_load_and_save_timeout(tmp_path: Path):
-    """Saving then loading should persist the timeout value."""
-    cfg = tmp_path / "config.ini"
-    # When file is missing, default should be 5
-    assert utils.load_timeout(cfg) == 5
-    # After saving a new value, it should round-trip
-    utils.save_timeout(10, cfg)
-    assert utils.load_timeout(cfg) == 10
-
-
 def test_load_and_save_working_dir(tmp_path: Path):
     """The last selected working directory should persist between runs."""
     cache = tmp_path / "dir.txt"

--- a/utils.py
+++ b/utils.py
@@ -78,36 +78,6 @@ def verify_api_key(api_key: str, request_fn: Callable = requests.get) -> bool:
     )
 
 
-def load_timeout(config_path: Path = CONFIG_PATH) -> int:
-    """Return timeout (minutes) from config or default to 5.
-
-    The config file uses a [ui] section; if it or the key is missing,
-    a default of 5 minutes is returned.
-    """
-    config = configparser.ConfigParser()
-    if config_path.exists():
-        config.read(config_path)
-    return config.getint("ui", "timeout_minutes", fallback=5)
-
-
-def save_timeout(value: int, config_path: Path = CONFIG_PATH) -> None:
-    """Persist the timeout value back to the config file.
-
-    Any existing configuration values (e.g. the default model) are preserved so
-    that updates feel "real-time" and no settings are lost when another one is
-    changed.
-    """
-    config = configparser.ConfigParser()
-    if config_path.exists():
-        config.read(config_path)
-    # Ensure required sections exist before assigning values
-    if "ui" not in config:
-        config["ui"] = {}
-    config["ui"]["timeout_minutes"] = str(value)
-    with open(config_path, "w") as fh:
-        config.write(fh)
-
-
 def load_default_model(config_path: Path = CONFIG_PATH) -> str:
     """Return the model to use on startup.
 


### PR DESCRIPTION
## Summary
- drop timeout configuration and settings UI
- stream aider output to track commit or user-input state
- add unit tests for run_aider's commit and prompt handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c04501bb20832d8dc373f979636aa1