### PR TITLE
Record aider exit code on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - Startup check that validates the `OPENAI_API_KEY` via a test API call.
 - Timeout for detecting the commit ID is adjustable (default 5 minutes) via a gear-icon settings dialog.
 - Each request receives a unique identifier and is logged in a table that shows commit ids, total line and file changes, and any failure reason. The history view abbreviates IDs so the table remains compact.
+- Failed runs record aider's exit code and last output line so troubleshooting is easier.
 - Timeout preference is saved to a small config file, but the model always defaults to **Medium** on startup.
 - The Send button has been removed—press **Enter** to dispatch a prompt.
 - A boxed status bar sits between the prompt area and the output, reporting whether we're waiting on aider or the user.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import io
 
 # Ensure project root is on path so we can import the package
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -35,6 +36,83 @@ def test_record_request_failure():
     assert rec["lines"] == 0
     assert rec["files"] == 0
     assert rec["failure_reason"] == "timeout"
+
+
+def test_run_aider_records_exit_reason(monkeypatch):
+    """run_aider should store exit code and last line on failure."""
+    runner.request_history.clear()
+
+    # Simple stand-ins for the Tk widgets so run_aider can interact with them
+    class DummyText:
+        def __init__(self):
+            self.text = ""
+
+        def insert(self, _idx, txt):
+            self.text += txt  # Append text to mimic a Tk widget
+
+        def see(self, _idx):
+            pass
+
+        def configure(self, **kwargs):
+            pass
+
+        def config(self, **kwargs):
+            pass
+
+        def focus_set(self):
+            pass
+
+    class DummyVar:
+        def set(self, _val):
+            pass
+
+    class DummyLabel:
+        def config(self, **kwargs):
+            pass
+
+        def unbind(self, *_args, **_kwargs):
+            pass
+
+    class DummyRoot:
+        def after(self, *_args, **_kwargs):
+            pass
+
+    # Mock Popen to simulate aider exiting with an error
+    class MockPopen:
+        def __init__(self, *args, **kwargs):
+            # Provide two lines of output, the last being an error
+            self.stdout = io.StringIO("ok\nboom\n")
+            self.returncode = 2
+
+        def wait(self):
+            return self.returncode
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *a, **k: MockPopen())
+
+    output = DummyText()
+    txt_input = DummyText()
+    status_var = DummyVar()
+    status_label = DummyLabel()
+    root = DummyRoot()
+
+    runner.run_aider(
+        msg="hi",
+        output_widget=output,
+        txt_input=txt_input,
+        work_dir=".",
+        model="gpt-5",
+        timeout_minutes=1,
+        status_var=status_var,
+        status_label=status_label,
+        request_id="req1",
+        root=root,
+    )
+
+    rec = runner.request_history[0]
+    assert rec["failure_reason"] == "aider exited with code 2: boom"
 
 
 class DummyWidget:


### PR DESCRIPTION
## Summary
- Track latest non-empty aider output and capture exit code when no commit is produced
- Record detailed failure reason including exit code and last line in request history
- Add unit test for error recording and document the behavior in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0472a1484832d8432ef7a40e0a517