### PR TITLE
Remove timeout handling and keep conversation history

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,13 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - Working directory chooser that shows the current path and remembers the last selection.
 - Multiline text area for composing prompts.
 - Startup check that validates the `OPENAI_API_KEY` via a test API call.
-- Timeout for detecting the commit ID is adjustable (default 5 minutes) via a gear-icon settings dialog.
 - Each request receives a unique identifier and is logged in a table that shows commit ids, total line and file changes, and any failure reason. The history view abbreviates IDs so the table remains compact.
-- Timeout preference is saved to a small config file, but the model always defaults to **Medium** on startup.
 - The Send button has been removed—press **Enter** to dispatch a prompt.
 - A boxed status bar sits between the prompt area and the output, reporting whether we're waiting on aider or the user.
 - After a successful commit, the status bar offers a **Test changes** link that builds and launches your Unity project via the command line. Configure the Unity Editor path via `config.ini` (`[build] build_cmd`), the `UNITY_PATH` environment variable, or let the app auto-detect a Unity Hub installation.
 - Draggable divider lets the prompt area take space from the response area when needed.
 - Successful commits highlight the status bar message in green.
-- After a successful commit, starting a new request clears prior output so separate conversations don't mix.
+- Output from previous requests remains visible so the full conversation can be reviewed.
 - An **API usage** button displays recent spending and remaining credits using the OpenAI billing API.
 
 ## Development Best Practices

--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,3 @@
-[ui]
-timeout_minutes = 1
-
 [aider]
 default_model = gpt-5-nano
 

--- a/nolight/app.py
+++ b/nolight/app.py
@@ -8,8 +8,6 @@ import uuid
 from utils import (
     sanitize,
     verify_api_key,
-    load_timeout,
-    save_timeout,
     load_working_dir,
     save_working_dir,
     load_usage_days,
@@ -42,39 +40,13 @@ def main() -> None:
     root.rowconfigure(0, weight=1)
     root.columnconfigure(0, weight=1)
 
-    # Default timeout pulled from config file and saved back when modified
-    timeout_var = tk.IntVar(value=load_timeout())
-
-    def on_timeout_change(*_args):
-        # Persist any changes to the timeout so it survives restarts
-        save_timeout(timeout_var.get())
-
-    timeout_var.trace_add("write", on_timeout_change)
-
     # Make the second column expandable so labels sit directly next to buttons
     for col in range(4):
         main_frame.columnconfigure(col, weight=1 if col == 1 else 0)
 
-    # API key status label
+    # API key status label spans the full row now that we have no settings button
     api_status_label = ttk.Label(main_frame, text="API key: checking...", foreground="orange")
-    # Span first three columns so a settings button can live in the fourth
-    api_status_label.grid(row=0, column=0, columnspan=3, sticky="w")
-
-    def open_settings() -> None:
-        """Pop up a small window to house UI-related settings."""
-        win = tk.Toplevel(root)
-        win.title("Settings")
-
-        ttk.Label(win, text="Timeout (min):").grid(row=0, column=0, padx=8, pady=8, sticky="w")
-        # The spinbox shares the same variable used in the main UI so changes
-        # automatically persist via the trace handler.
-        ttk.Spinbox(win, from_=1, to=60, textvariable=timeout_var, width=5).grid(
-            row=0, column=1, padx=8, pady=8, sticky="w"
-        )
-
-    # Simple gear icon button that opens the settings window
-    settings_btn = ttk.Button(main_frame, text="⚙", width=3, command=open_settings)
-    settings_btn.grid(row=0, column=3, sticky="e")
+    api_status_label.grid(row=0, column=0, columnspan=4, sticky="w")
 
     # Project directory selector
     work_dir_var = tk.StringVar(value="")
@@ -154,8 +126,6 @@ def main() -> None:
             output.configure(state="disabled")
             return
         msg = sanitize(raw)
-        # Remove old output if the last request finished with a commit.
-        runner.maybe_clear_output(output)
         # Disable input until aider responds so duplicate requests can't be sent.
         txt_input.config(state="disabled")
         # Generate a new request id only if we're starting a fresh request.
@@ -173,11 +143,9 @@ def main() -> None:
                 txt_input,
                 work_dir_var.get(),
                 model,
-                timeout_var.get(),  # Minutes to wait for commit id
                 status_var,
                 status_label,
                 req_id,
-                root,
             ),
             daemon=True,
         )

--- a/nolight/runner.py
+++ b/nolight/runner.py
@@ -1,5 +1,4 @@
 import subprocess
-import time
 from typing import Optional, List
 
 import tkinter as tk
@@ -17,8 +16,6 @@ from utils import (
 request_history: List[dict] = []  # List of per-request summaries
 current_request_id: Optional[str] = None  # UUID for the active request
 request_active = False  # True while we're waiting on aider to finish
-# When set, the next request should clear the output widget before running.
-reset_on_new_request = False
 
 
 def record_request(
@@ -69,33 +66,15 @@ def record_request(
     )
 
 
-def maybe_clear_output(output_widget: tk.Text) -> None:
-    """Erase old output if a previous request succeeded.
-
-    The UI calls this right before starting a new request. If a prior request
-    finished with a commit, we wipe the output widget so two conversations don't
-    run together. Afterwards, the reset flag is cleared.
-    """
-
-    global reset_on_new_request
-    if reset_on_new_request and not request_active:
-        output_widget.configure(state="normal")
-        output_widget.delete("1.0", tk.END)
-        output_widget.configure(state="disabled")
-        reset_on_new_request = False
-
-
 def run_aider(
     msg: str,
     output_widget: tk.Text,
     txt_input: tk.Text,
     work_dir: str,
     model: str,
-    timeout_minutes: int,
     status_var: tk.StringVar,
     status_label: ttk.Label,
     request_id: str,
-    root: tk.Tk,
 ) -> None:
     """Spawn the aider CLI and capture commit details.
 
@@ -104,7 +83,7 @@ def run_aider(
     ``request_history`` so the user can review past actions.
     """
 
-    global request_active, reset_on_new_request
+    global request_active
     # Ensure the status bar is reset for each new request by removing any
     # previous click handlers and cursor styling.
     status_label.config(cursor="")
@@ -114,14 +93,8 @@ def run_aider(
         # Automatically answer "yes" to any prompts so the UI never hangs.
         cmd_args = ["aider", "--yes-always", "--model", model, "--message", msg]
 
-        # Let the user know we're waiting on aider and start a simple countdown
-        # so they can see when a timeout will occur.
-        update_status(
-            status_var,
-            status_label,
-            f"Waiting on aider's response... {timeout_minutes * 60} seconds to timeout",
-            "black",
-        )
+        # Notify the user that we're awaiting aider's response.
+        update_status(status_var, status_label, "Waiting on aider's response...", "black")
 
         output_widget.configure(state="normal")
         output_widget.insert(
@@ -142,29 +115,9 @@ def run_aider(
             errors="replace",
         )
 
-        start_time = time.time()
         commit_id: Optional[str] = None
         failure_reason: Optional[str] = None
         waiting_on_user = False  # Set when aider asks for more information
-
-        def update_countdown() -> None:
-            """Refresh the status bar every second with remaining time."""
-
-            elapsed = time.time() - start_time
-            remaining = int(timeout_minutes * 60 - elapsed)
-            # Stop updating once we have a result or are waiting on the user.
-            if commit_id or failure_reason or waiting_on_user or remaining < 0:
-                return
-            update_status(
-                status_var,
-                status_label,
-                f"Waiting on aider's response... {remaining} seconds to timeout",
-                "black",
-            )
-            root.after(1000, update_countdown)
-
-        # Kick off the countdown updates using the Tk root from the caller.
-        root.after(1000, update_countdown)
 
         # Read line-by-line so the UI stays responsive.
         for line in proc.stdout:
@@ -180,27 +133,10 @@ def run_aider(
             if cid:
                 commit_id = cid
 
-            # If aider is asking for more information, stop the process and let
-            # the user reply instead of timing out.
+            # If aider asks for more details, stop the process so the user can reply.
             if needs_user_input(line):
                 waiting_on_user = True
                 update_status(status_var, status_label, "Aider is waiting on our input", "orange")
-                proc.kill()
-                break
-
-            # Stop waiting if timeout elapsed without a commit id.
-            if (
-                commit_id is None
-                and not waiting_on_user
-                and time.time() - start_time > timeout_minutes * 60
-            ):
-                failure_reason = "Timed out waiting for commit id"
-                update_status(
-                    status_var,
-                    status_label,
-                    "Failed to make commit due to timeout",
-                    "red",
-                )
                 proc.kill()
                 break
 
@@ -230,8 +166,6 @@ def run_aider(
                     f"Made commit {commit_id} but failed to gather stats",
                     "red",
                 )
-            # Mark that the next request should start with a clean output box.
-            reset_on_new_request = True
             request_active = False
         elif waiting_on_user:
             # No commit hash yet because aider needs more input. Leave the

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,5 +1,8 @@
 import sys
 from pathlib import Path
+import types
+
+import pytest
 
 # Ensure project root is on path so we can import the package
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -29,45 +32,153 @@ def test_record_request_success():
 def test_record_request_failure():
     """Failures should record the reason and zero counts."""
     runner.request_history.clear()
-    runner.record_request("id2", None, failure_reason="timeout")
+    runner.record_request("id2", None, failure_reason="error")
     rec = runner.request_history[0]
     assert rec["commit_id"] is None
     assert rec["lines"] == 0
     assert rec["files"] == 0
-    assert rec["failure_reason"] == "timeout"
+    assert rec["failure_reason"] == "error"
 
 
-class DummyWidget:
-    """Minimal stand-in for a Tk text widget used in tests."""
+def test_run_aider_records_commit(monkeypatch, tmp_path):
+    """A commit hash in aider's output should record the request and end the run."""
 
-    def __init__(self):
-        self.content = "hello"
-        self.state = "normal"
+    class DummyText:
+        """Simplified stand-in for Tk's Text widget."""
 
-    def configure(self, state: str) -> None:
-        # Store the state but ignore it otherwise.
-        self.state = state
+        def __init__(self):
+            self.state = "normal"
 
-    def delete(self, start: str, end: str) -> None:
-        # Simulate clearing all text from the widget.
-        self.content = ""
+        def configure(self, **_):
+            pass
+
+        def insert(self, _idx, _text):
+            pass
+
+        def see(self, _idx):
+            pass
+
+        def config(self, **kwargs):  # for txt_input
+            self.state = kwargs.get("state", self.state)
+
+        def focus_set(self):
+            pass
+
+    class DummyVar:
+        def __init__(self):
+            self.value = ""
+
+        def set(self, value):
+            self.value = value
+
+    class DummyLabel:
+        def config(self, **_):
+            pass
+
+        def unbind(self, _):
+            pass
+
+    # Simulate aider emitting a commit line
+    lines = iter(["Committed abcdef1 add feature\n"])
+
+    class FakeProc:
+        def __init__(self):
+            self.stdout = lines
+            self.returncode = 0
+
+        def kill(self):
+            pass
+
+        def wait(self):
+            pass
+
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *a, **k: FakeProc())
+    monkeypatch.setattr(
+        runner,
+        "get_commit_stats",
+        lambda cid, wd: {"lines_changed": 1, "files_changed": 0, "files_added": 0, "files_removed": 0, "description": "msg"},
+    )
+
+    out = DummyText()
+    inp = DummyText()
+    var = DummyVar()
+    lbl = DummyLabel()
+
+    runner.request_history.clear()
+    runner.request_active = True
+    runner.run_aider("msg", out, inp, str(tmp_path), "model", var, lbl, "req1")
+
+    assert runner.request_history[0]["commit_id"] == "abcdef1"
+    assert not runner.request_active  # run ended after commit
+    assert "Successfully" in var.value
 
 
-def test_maybe_clear_output_resets_when_flag_set():
-    """Output should be cleared and flag reset when marked for reset."""
-    widget = DummyWidget()
-    runner.reset_on_new_request = True
-    runner.request_active = False
-    runner.maybe_clear_output(widget)
-    assert widget.content == ""
-    assert runner.reset_on_new_request is False
+def test_run_aider_waits_on_user(monkeypatch, tmp_path):
+    """When aider requests input, the run should stop without recording a commit."""
 
+    class DummyText:
+        def __init__(self):
+            self.state = "normal"
 
-def test_maybe_clear_output_no_reset_when_flag_unset():
-    """Widget remains unchanged if reset flag is not set."""
-    widget = DummyWidget()
-    widget.content = "stay"
-    runner.reset_on_new_request = False
-    runner.request_active = False
-    runner.maybe_clear_output(widget)
-    assert widget.content == "stay"
+        def configure(self, **_):
+            pass
+
+        def insert(self, _idx, _text):
+            pass
+
+        def see(self, _idx):
+            pass
+
+        def config(self, **kwargs):
+            self.state = kwargs.get("state", self.state)
+
+        def focus_set(self):
+            pass
+
+    class DummyVar:
+        def __init__(self):
+            self.value = ""
+
+        def set(self, value):
+            self.value = value
+
+    class DummyLabel:
+        def config(self, **_):
+            pass
+
+        def unbind(self, _):
+            pass
+
+    # Line mimics aider asking for more details
+    lines = iter([
+        "Please add README.md to the chat so I can generate the exact SEARCH/REPLACE blocks?\n"
+    ])
+
+    class FakeProc:
+        def __init__(self):
+            self.stdout = lines
+            self.returncode = 0
+            self.killed = False
+
+        def kill(self):
+            self.killed = True
+
+        def wait(self):
+            pass
+
+    fake = FakeProc()
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *a, **k: fake)
+
+    out = DummyText()
+    inp = DummyText()
+    var = DummyVar()
+    lbl = DummyLabel()
+
+    runner.request_history.clear()
+    runner.request_active = True
+    runner.run_aider("msg", out, inp, str(tmp_path), "model", var, lbl, "req2")
+
+    assert runner.request_history == []  # no commit recorded
+    assert runner.request_active  # still waiting for follow-up input
+    assert "waiting" in var.value.lower()
+    assert fake.killed  # process should be terminated

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,16 +90,6 @@ def test_needs_user_input_ignores_regular_output():
     assert not utils.needs_user_input(line)
 
 
-def test_load_and_save_timeout(tmp_path: Path):
-    """Saving then loading should persist the timeout value."""
-    cfg = tmp_path / "config.ini"
-    # When file is missing, default should be 5
-    assert utils.load_timeout(cfg) == 5
-    # After saving a new value, it should round-trip
-    utils.save_timeout(10, cfg)
-    assert utils.load_timeout(cfg) == 10
-
-
 def test_load_and_save_working_dir(tmp_path: Path):
     """The last selected working directory should persist between runs."""
     cache = tmp_path / "dir.txt"

--- a/utils.py
+++ b/utils.py
@@ -78,36 +78,6 @@ def verify_api_key(api_key: str, request_fn: Callable = requests.get) -> bool:
     )
 
 
-def load_timeout(config_path: Path = CONFIG_PATH) -> int:
-    """Return timeout (minutes) from config or default to 5.
-
-    The config file uses a [ui] section; if it or the key is missing,
-    a default of 5 minutes is returned.
-    """
-    config = configparser.ConfigParser()
-    if config_path.exists():
-        config.read(config_path)
-    return config.getint("ui", "timeout_minutes", fallback=5)
-
-
-def save_timeout(value: int, config_path: Path = CONFIG_PATH) -> None:
-    """Persist the timeout value back to the config file.
-
-    Any existing configuration values (e.g. the default model) are preserved so
-    that updates feel "real-time" and no settings are lost when another one is
-    changed.
-    """
-    config = configparser.ConfigParser()
-    if config_path.exists():
-        config.read(config_path)
-    # Ensure required sections exist before assigning values
-    if "ui" not in config:
-        config["ui"] = {}
-    config["ui"]["timeout_minutes"] = str(value)
-    with open(config_path, "w") as fh:
-        config.write(fh)
-
-
 def load_default_model(config_path: Path = CONFIG_PATH) -> str:
     """Return the model to use on startup.
 


### PR DESCRIPTION
## Summary
- Drop timeout configuration and related utilities
- Keep full conversation history and remove UI settings dialog
- Add runner tests for commit capture and user prompts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c047aff800832da81264c4f4da571e