### PR TITLE
Add Unity build button

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - The Send button has been removed—press **Enter** to dispatch a prompt.
 - A boxed status bar sits between the prompt area and the output, showing detailed status for each request and whether we're waiting on aider or the user.
 - After a successful commit, the status bar offers a **Test changes** link that builds and launches your Unity project via the command line. Configure the Unity Editor path via `config.ini` (`[build] build_cmd`), the `UNITY_PATH` environment variable, or let the app auto-detect a Unity Hub installation.
+- A **Build & Run** button in the top-right corner lets you compile and launch the Unity project at any time to quickly test the latest changes.
 - Draggable divider lets the prompt area take space from the response area when needed.
 - Successful commits highlight the status bar message in green.
 - After a successful commit, starting a new request clears prior output so separate conversations don't mix.

--- a/nolight/app.py
+++ b/nolight/app.py
@@ -13,6 +13,7 @@ from utils.config import (
     load_working_dir,
     save_working_dir,
     load_usage_days,
+    build_and_launch_game,
 )
 from utils.git import format_history_row, HISTORY_COL_WIDTHS
 
@@ -27,6 +28,18 @@ MODEL_OPTIONS = {
 
 # Always start with the medium model; the choice isn't persisted between runs.
 DEFAULT_CHOICE = "Medium"
+
+
+def launch_game() -> None:
+    """Build and start the Unity project, showing any failures."""
+    try:
+        # Run the build and launch command; any configuration is handled
+        # inside ``build_and_launch_game``.
+        build_and_launch_game()
+    except Exception as exc:
+        # Surface errors to the user instead of failing silently so they can
+        # fix configuration issues such as a missing Unity installation.
+        messagebox.showerror("Build failed", str(exc))
 
 
 def main() -> None:
@@ -44,10 +57,16 @@ def main() -> None:
     for col in range(4):
         main_frame.columnconfigure(col, weight=1 if col == 1 else 0)
 
-    # API key status label
+    # API key status label sits on the left while the build button uses the
+    # rightmost column. The label spans three columns so it does not overlap
+    # the new button.
     api_status_label = ttk.Label(main_frame, text="API key: checking...", foreground="orange")
-    # Span all columns since the settings button was removed
-    api_status_label.grid(row=0, column=0, columnspan=4, sticky="w")
+    api_status_label.grid(row=0, column=0, columnspan=3, sticky="w")
+
+    # Button in the top-right corner lets the user build and run the game at
+    # any time for quick testing of changes.
+    build_btn = ttk.Button(main_frame, text="Build & Run", command=launch_game)
+    build_btn.grid(row=0, column=3, sticky="e")
 
     # Project directory selector
     work_dir_var = tk.StringVar(value="")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,48 @@
+"""Tests for the top-level build-and-run button logic."""
+
+import sys
+from pathlib import Path
+
+# Ensure project root is on path so the UI module can be imported
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import nolight.app as app
+
+
+def test_launch_game_invokes_builder(monkeypatch):
+    """Successful builds should call the builder and show no error."""
+
+    calls = []
+
+    def fake_build():
+        """Pretend to build the game successfully."""
+        calls.append("build")
+
+    # Replace the real build function with our fake to capture invocation.
+    monkeypatch.setattr(app, "build_and_launch_game", fake_build)
+    # Stub out the error dialog to ensure it is not triggered on success.
+    monkeypatch.setattr(app.messagebox, "showerror", lambda *_: calls.append("error"))
+
+    app.launch_game()
+
+    # Only the build function should have been called.
+    assert calls == ["build"]
+
+
+def test_launch_game_shows_error_on_failure(monkeypatch):
+    """Failures should surface to the user via a dialog."""
+
+    errors = []
+
+    def fake_build():
+        """Simulate the build step raising an error."""
+        raise FileNotFoundError("missing unity")
+
+    monkeypatch.setattr(app, "build_and_launch_game", fake_build)
+    monkeypatch.setattr(app.messagebox, "showerror", lambda title, msg: errors.append((title, msg)))
+
+    app.launch_game()
+
+    # The error dialog should report the reason for the failure.
+    assert errors == [("Build failed", "missing unity")]
+


### PR DESCRIPTION
## Summary
- add global `launch_game` helper that wraps Unity build and shows errors
- add top-right Build & Run button wired to new helper
- document new build button and cover it with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c05336c410832dbc20bef3901a7a6e