### PR TITLE
Improve Unity build error reporting and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - A boxed status bar sits between the prompt area and the output, showing detailed status for each request and whether we're waiting on aider or the user.
 - After a successful commit, the status bar offers a **Test changes** link that builds and launches your Unity project via the command line. Configure the Unity Editor path via `config.ini` (`[build] build_cmd`), the `UNITY_PATH` environment variable, or let the app auto-detect a Unity Hub installation.
 - A **Build & Run** button in the top-right corner lets you compile and launch the Unity project at any time to quickly test the latest changes.
+- Build failures surface a dialog showing Unity's log tail so issues can be diagnosed without hunting for files.
 - Draggable divider lets the prompt area take space from the response area when needed.
 - Successful commits highlight the status bar message in green.
 - After a successful commit, starting a new request clears prior output so separate conversations don't mix.

--- a/nolight/app.py
+++ b/nolight/app.py
@@ -1,7 +1,8 @@
 import threading
 import subprocess
 import tkinter as tk
-from tkinter import ttk, filedialog
+# Import common Tk widgets plus ``messagebox`` for error dialogs.
+from tkinter import ttk, filedialog, messagebox
 import os
 import uuid
 


### PR DESCRIPTION
## Summary
- import Tkinter `messagebox` so build failures show a dialog
- capture Unity batch build logs and raise detailed errors
- extend tests to cover subprocess failures and log tail reporting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c063986378832da4f4355bee8878bd