### PR TITLE
fix: sanitize aider output to remove ANSI codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - Draggable divider lets the prompt area take space from the response area when needed.
 - Successful commits highlight the status bar message in green.
 - After a successful commit, starting a new request clears prior output so separate conversations don't mix.
+- Aider output is sanitized to remove ANSI color codes so messages display cleanly.
 - Each request records its cost in dollars and the total session spend is shown in the main window.
 
 ## Development Best Practices


### PR DESCRIPTION
## Summary
- strip ANSI color codes before displaying aider output so commit messages don't show escape sequences
- verify colored output is cleaned and commit IDs still captured
- document that the UI sanitizes aider output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c088c445cc832daf972781e983f481