### PR TITLE
Forward Unity project path for builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - The Send button has been removed—press **Enter** to dispatch a prompt.
 - A boxed status bar sits between the prompt area and the output, showing detailed status for each request and whether we're waiting on aider or the user. When more details are needed, it explicitly tells you to provide the requested files or answers.
 - After a successful commit, the status bar offers a **Test changes** link that builds and launches your Unity project via the command line. Configure the Unity Editor path via `config.ini` (`[build] build_cmd`), the `UNITY_PATH` environment variable, or let the app auto-detect a Unity Hub installation.
-- A **Build & Run** button in the top-right corner lets you compile and launch the Unity project at any time to quickly test the latest changes.
+  - A **Build & Run** button in the top-right corner uses the selected working directory as the Unity project path and invokes `RogueLike2D.Editor.BuildScript.PerformBuild` to compile and launch the game.
 - Build failures surface a dialog showing Unity's log tail so issues can be diagnosed without hunting for files.
 - Draggable divider lets the prompt area take space from the response area when needed.
 - Successful commits highlight the status bar message in green.

--- a/nolight/app.py
+++ b/nolight/app.py
@@ -30,12 +30,12 @@ MODEL_OPTIONS = {
 DEFAULT_CHOICE = "Medium"
 
 
-def launch_game() -> None:
-    """Build and start the Unity project, showing any failures."""
+def launch_game(project_path: str) -> None:
+    """Build and start the Unity project located at ``project_path``."""
     try:
-        # Run the build and launch command; any configuration is handled
-        # inside ``build_and_launch_game``.
-        build_and_launch_game()
+        # Pass the user-selected working directory to the builder so Unity
+        # knows which project to compile.
+        build_and_launch_game(project_path=project_path)
     except Exception as exc:
         # Surface errors to the user instead of failing silently so they can
         # fix configuration issues such as a missing Unity installation.
@@ -61,8 +61,13 @@ def build_ui(root: tk.Tk):
     api_status_label.grid(row=0, column=0, columnspan=3, sticky="w")
 
     # Button in the top-right corner lets the user build and run the game at
-    # any time for quick testing of changes.
-    build_btn = ttk.Button(main_frame, text="Build & Run", command=launch_game)
+    # any time for quick testing of changes. The selected working directory is
+    # forwarded so Unity knows which project to compile.
+    build_btn = ttk.Button(
+        main_frame,
+        text="Build & Run",
+        command=lambda: launch_game(work_dir_var.get()),
+    )
     build_btn.grid(row=0, column=3, sticky="e")
 
     # Project directory selector

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -10,23 +10,24 @@ import nolight.app as app
 
 
 def test_launch_game_invokes_builder(monkeypatch):
-    """Successful builds should call the builder and show no error."""
+    """Successful builds should call the builder with the selected path."""
 
     calls = []
 
-    def fake_build():
+    def fake_build(*, project_path):
         """Pretend to build the game successfully."""
-        calls.append("build")
+        # Record the project path to ensure it was forwarded correctly.
+        calls.append(project_path)
 
     # Replace the real build function with our fake to capture invocation.
     monkeypatch.setattr(app, "build_and_launch_game", fake_build)
     # Stub out the error dialog to ensure it is not triggered on success.
     monkeypatch.setattr(app.messagebox, "showerror", lambda *_: calls.append("error"))
 
-    app.launch_game()
+    app.launch_game("/tmp/project")
 
-    # Only the build function should have been called.
-    assert calls == ["build"]
+    # Only the build function should have been called with the given path.
+    assert calls == ["/tmp/project"]
 
 
 def test_launch_game_shows_error_on_failure(monkeypatch):
@@ -34,14 +35,14 @@ def test_launch_game_shows_error_on_failure(monkeypatch):
 
     errors = []
 
-    def fake_build():
+    def fake_build(*, project_path):
         """Simulate the build step raising an error."""
         raise FileNotFoundError("missing unity")
 
     monkeypatch.setattr(app, "build_and_launch_game", fake_build)
     monkeypatch.setattr(app.messagebox, "showerror", lambda title, msg: errors.append((title, msg)))
 
-    app.launch_game()
+    app.launch_game("/tmp/project")
 
     # The error dialog should report the reason for the failure.
     assert errors == [("Build failed", "missing unity")]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -366,7 +366,13 @@ def test_build_and_launch_game_uses_finder(monkeypatch, tmp_path):
 
     proc = config_utils.build_and_launch_game(run_cmd=[str(game)])
 
-    assert calls[0][1][0] == str(unity)
+    cmd = calls[0][1]
+    assert cmd[0] == str(unity)
+    # Ensure the fully-qualified build method is included in the command.
+    idx = cmd.index("-executeMethod")
+    assert (
+        cmd[idx + 1] == "RogueLike2D.Editor.BuildScript.PerformBuild"
+    )
     assert isinstance(proc, types.SimpleNamespace)
 
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -95,9 +95,18 @@ def build_and_launch_game(
     run_cmd=None,
     project_path=None,
     unity_exe=None,
-    method="BuildScript.PerformBuild",
+    method="RogueLike2D.Editor.BuildScript.PerformBuild",
 ):
-    """Build the Unity project then start the resulting executable."""
+    """Build the Unity project then start the resulting executable.
+
+    Parameters
+    ----------
+    method:
+        Fully-qualified Unity method used to trigger the build. The default
+        targets ``RogueLike2D.Editor.BuildScript.PerformBuild`` which wraps the
+        project's Windows build logic. The command list avoids shell quoting so
+        paths with spaces remain intact.
+    """
     if build_cmd is None:
         # Resolve ``Unity.exe`` and construct the batch build command.
         unity_exe = unity_exe or _find_unity_exe()


### PR DESCRIPTION
## Summary
- Pass the selected working directory to `build_and_launch_game` so Unity builds use the correct project path
- Default Unity build method is now fully qualified (`RogueLike2D.Editor.BuildScript.PerformBuild`)
- Document Build & Run behavior and expand tests for build command generation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c08b48a9c4832d91bf6465462328d0