### PR TITLE
Surface Unity build errors when game binary missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - A boxed status bar sits between the prompt area and the output, showing detailed status for each request and whether we're waiting on aider or the user. When more details are needed, it explicitly tells you to provide the requested files or answers.
 - After a successful commit, the status bar offers a **Test changes** link that builds and launches your Unity project via the command line. Configure the Unity Editor path via `config.ini` (`[build] build_cmd`), the `UNITY_PATH` environment variable, or let the app auto-detect a Unity Hub installation.
   - A **Build & Run** button in the top-right corner uses the selected working directory as the Unity project path and invokes `RogueLike2D.Editor.BuildScript.PerformBuild` to compile and launch the game.
-  - Build failures open a scrollable dialog showing Unity's log tail so long stack traces can be reviewed and copied without hunting for files.
+- Build failures, including missing game binaries, open a scrollable dialog showing Unity's log tail and stderr so long stack traces can be reviewed and copied without hunting for files.
 - Draggable divider lets the prompt area take space from the response area when needed.
 - Successful commits highlight the status bar message in green.
 - After a successful commit, starting a new request clears prior output so separate conversations don't mix.


### PR DESCRIPTION
## Summary
- include helper to tail Unity logs and expose build problems
- surface stderr and log tail when Unity build succeeds but exe is missing
- document and test the missing-executable error reporting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0921294a4832d85e19310fc93c3d4