### PR TITLE
Add robust Unity build output handling

### DIFF
--- a/NoLightUnityProject/Assets/Editor/BuildScript.cs
+++ b/NoLightUnityProject/Assets/Editor/BuildScript.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using UnityEditor.Build.Reporting;
+
+// This editor script performs a Windows build.
+// Unity is invoked in batch mode and can optionally accept a custom output path
+// via the -customBuildPath command line argument.
+
+namespace RogueLike2D.Editor
+{
+    public static class BuildScript
+    {
+        public static void PerformWindowsBuild()
+        {
+            // Gather enabled scenes from the Build Settings.
+            var scenes = EditorBuildSettings.scenes.Where(s => s.enabled).Select(s => s.path).ToArray();
+            if (scenes == null || scenes.Length == 0)
+            {
+                Debug.LogError("No enabled scenes found in Build Settings. Aborting build.");
+                return;
+            }
+
+            // Allow -customBuildPath "C:\\...\\Builds\\Windows\\NoLight.exe"
+            string custom = GetArg("-customBuildPath");
+            string exePath = string.IsNullOrEmpty(custom)
+                ? System.IO.Path.Combine("Builds/Windows", "RogueLike2D.exe") // default
+                : custom;
+
+            System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(exePath));
+
+            var buildOptions = new BuildPlayerOptions
+            {
+                scenes = scenes,
+                locationPathName = exePath,
+                target = BuildTarget.StandaloneWindows64,
+                options = BuildOptions.None
+            };
+
+            Debug.Log($"Starting build to {exePath}");
+            var report = BuildPipeline.BuildPlayer(buildOptions);
+            Debug.Log($"Build Finished, Result: {report.summary.result}.");
+            if (report.summary.result == BuildResult.Succeeded)
+                Debug.Log($"Build succeeded: {exePath} ({report.summary.totalSize} bytes)");
+            else
+                Debug.LogError($"Build failed with {report.summary.result}.");
+        }
+
+        // Helper to fetch a command line argument's value.
+        static string GetArg(string name)
+        {
+            var args = System.Environment.GetCommandLineArgs();
+            for (int i = 0; i < args.Length - 1; i++)
+                if (args[i] == name) return args[i + 1];
+            return null;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - The Send button has been removed—press **Enter** to dispatch a prompt.
 - A boxed status bar sits between the prompt area and the output, showing detailed status for each request and whether we're waiting on aider or the user. When more details are needed, it explicitly tells you to provide the requested files or answers.
 - After a successful commit, the status bar offers a **Test changes** link that builds and launches your Unity project via the command line. Configure the Unity Editor path via `config.ini` (`[build] build_cmd`), the `UNITY_PATH` environment variable, or let the app auto-detect a Unity Hub installation.
-  - A **Build & Run** button in the top-right corner uses the selected working directory as the Unity project path and invokes `RogueLike2D.Editor.BuildScript.PerformBuild` to compile and launch the game.
+  - A **Build & Run** button in the top-right corner uses the selected working directory as the Unity project path and invokes `RogueLike2D.Editor.BuildScript.PerformWindowsBuild` to compile and launch the game. The build step receives a custom output path and the launcher falls back to the first `.exe` in the build folder if the expected name is missing.
 - Build failures, including missing game binaries, open a scrollable dialog showing Unity's log tail and stderr so long stack traces can be reviewed and copied without hunting for files.
 - Draggable divider lets the prompt area take space from the response area when needed.
 - Successful commits highlight the status bar message in green.


### PR DESCRIPTION
## Summary
- allow Unity build script to accept custom output path via `-customBuildPath`
- locate built game executables dynamically and fall back to the first `.exe`
- document new build process and update tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0a2306b24832d8d2e6f180dfd7450