### PR TITLE
Clear input field after sending prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 - Each aider request automatically attaches `AGENTS.md` and `README.md` so
   project rules and high-level context are always applied.
 - Each request records its cost in dollars and the total session spend is shown in the main window.
+ - After sending a prompt, the input box clears so the next message can be typed immediately.
 
 ## Development Best Practices
 

--- a/nolight/app.py
+++ b/nolight/app.py
@@ -178,6 +178,8 @@ def build_ui(root: tk.Tk):
         msg = sanitize(raw)
         # Remove old output if the last request finished with a commit.
         runner.maybe_clear_output(output)
+        # Remove the user's prompt so the box is ready for the next message.
+        txt_input.delete("1.0", tk.END)
         # Disable input until aider responds so duplicate requests can't be sent.
         txt_input.config(state="disabled")
         # Generate a new request id only if we're starting a fresh request.
@@ -204,7 +206,6 @@ def build_ui(root: tk.Tk):
             daemon=True,
         )
         t.start()
-        txt_input.delete("1.0", tk.END)
 
     def on_return(event):
         on_send()
@@ -329,6 +330,10 @@ def build_ui(root: tk.Tk):
         "model_label": model_label,
         "model_combo": model_combo,
         "prompt_label": lbl,
+        # Return the input widget so tests can simulate user typing.
+        "txt_input": txt_input,
+        # Expose the working directory variable for test configuration.
+        "work_dir_var": work_dir_var,
     }
 
     return widgets, check_api_key


### PR DESCRIPTION
## Summary
- Clear the prompt text box immediately after sending a message
- Expose input widgets for testing and document new behavior
- Test that submitting a prompt wipes the input field

## Testing
- `pytest --cov=. --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_68c19bdec778832da6d5574163ceab10