### PR TITLE
Run tests in parallel with per-test timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ A small Tkinter-based interface for sending prompts to the [`aider`](https://git
 ## Development Best Practices
 
 - Add tests for functionality changes to verify new behavior.
+- The test suite runs in parallel with a 5-second timeout per test, so
+  no single test can stall the run and failures never stop subsequent tests.
 - Break up and modularize code where possible to reduce merge conflicts.
 - Utility helpers live in focused modules (e.g., `utils.text`, `utils.config`)
   so changes stay scoped to their domain.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = --cov=. --cov-report=term-missing -n auto --maxfail=0 --timeout=5
+# Use thread-based timeouts for cross-platform compatibility
+# so tests don't rely on OS-specific signal handling.
+timeout_method = thread

--- a/tests/test_pytest_config.py
+++ b/tests/test_pytest_config.py
@@ -1,0 +1,15 @@
+import os
+
+
+def test_timeout_config(pytestconfig):
+    """Ensure each test has a 5 second timeout to prevent hangs."""
+    # The timeout plugin should enforce a 5 second limit per test.
+    assert pytestconfig.getoption("timeout") == 5
+
+
+def test_parallel_execution(pytestconfig):
+    """Ensure tests run in parallel to speed up the suite."""
+    # xdist sets this environment variable on each worker process to the
+    # total number of workers, so a value greater than 1 implies parallelism.
+    worker_count = os.environ.get("PYTEST_XDIST_WORKER_COUNT")
+    assert worker_count is not None and int(worker_count) > 1


### PR DESCRIPTION
## Summary
- document that tests run in parallel with per-test timeout
- configure pytest to run tests in parallel, time out each test after 5s, and continue after failures
- add tests to verify timeout and parallel xdist configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c305aefaa8832db07641f5346e60d2